### PR TITLE
ignore python modules made available by existing packages

### DIFF
--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -292,8 +292,7 @@ type LanguageBackend struct {
 	// sorry: only packages which are *definitely* project
 	// dependencies should be returned. Names should be returned
 	// in a format suitable for the Add method. There is no need
-	// to consult the specfile; return all guessed packages, even
-	// those already listed.
+	// to eliminate packages already installed.
 	//
 	// The second value indicates whether the bare imports search
 	// was fully successful. One reason why it might not be


### PR DESCRIPTION
Trusting package guessing leads to an issue where multiple packages providing
the same module can inadvertently be both installed. This happens when different
packages each rank as the best guess for modules provided by the same package.

Although it is somewhat incorrect as transitive deps could cause some packages
to be incorrectly skipped. The end behavior makes things a bit more reliable.

Perhaps it'd better to determine the fewest number of packages to satisfy all
modules, but this seems to work well enough for now.

here's a repl using this new behavior: https://repl.it/@turbio/upm-testing
notice that websocket isn't installed because it is made available by discord