### PR TITLE
[PKGBUILD] Ensure it follows guidelines

### DIFF
--- a/packaging/aur/.SRCINFO
+++ b/packaging/aur/.SRCINFO
@@ -1,11 +1,12 @@
-pkgbase = upm
+pkgbase = upm-bin
 	pkgdesc = Universal package manager: Python, Node.js, Ruby, Emacs Lisp.
 	pkgver = 1.0
 	pkgrel = 1
-	arch = any
+	url = https://repl.it/site/blog/upm
+	arch = x86_64
 	license = MIT
 	source = https://github.com/replit/upm/releases/download/v1.0/upm_1.0_linux_amd64.tar.gz
-	md5sums = b5447e9387ac5d9c0d7c78106941cbef
+	sha256sums = 3f02ccd8bf5d486f1809dc73566c9be41b265626ad0ca7b062d1739505a819b4
 
-pkgname = upm
+pkgname = upm-bin
 

--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -1,15 +1,16 @@
 # Maintainer: Repl.it <contact+upm@repl.it>
-pkgname=upm
+
+pkgname=upm-bin
 pkgver=1.0
 pkgrel=1
 pkgdesc="Universal package manager: Python, Node.js, Ruby, Emacs Lisp."
-arch=('any')
-url=""
+arch=('x86_64')
+url="https://repl.it/site/blog/upm"
 license=('MIT')
 source=("https://github.com/replit/upm/releases/download/v${pkgver}/upm_${pkgver}_linux_amd64.tar.gz")
-md5sums=('b5447e9387ac5d9c0d7c78106941cbef')
+sha256sums=('3f02ccd8bf5d486f1809dc73566c9be41b265626ad0ca7b062d1739505a819b4')
 
 package() {
-  install -d "${pkgdir}/usr/bin"
-  cp "upm" "${pkgdir}/usr/bin/"
+  install -Dm755 upm "$pkgdir"/usr/bin/$pkgname
+  install -Dm644 LICENSE.md "$pkgdir"/usr/share/licenses/$pkgname/LICENSE
 }


### PR DESCRIPTION
Binary packages should have the -bin suffix if the source is available.
Because it's a precompiled binary, this won't work on any architecture,
thus we change it to `x86_64`. License is also unique, so added to the
license directories.


I see you have already uploaded the package to AUR [with a bot](https://aur.archlinux.org/packages/upm/). Needs to have `upm-bin`  created and then we can do a merge request to rename the package. 


Please ask if there is any questions regarding packaging and/or AUR.