### PR TITLE
add java-maven backend

### DIFF
--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -315,30 +315,39 @@ type LanguageBackend struct {
 // a builder function which can perform this normalization and
 // validation.
 func (b *LanguageBackend) Setup() {
-	if b.Name == "" ||
-		b.Specfile == "" ||
-		b.Lockfile == "" ||
-		len(b.FilenamePatterns) == 0 ||
-		b.GetPackageDir == nil ||
-		b.Search == nil ||
-		b.Info == nil ||
-		b.Add == nil ||
-		b.Remove == nil ||
+	condition2flag := map[string]bool{
+		"b.Name == \"\"": b.Name == "",
+		"b.Specfile == \"\"": b.Specfile == "",
+		"b.Lockfile == \"\"": b.Lockfile == "",
+		"len(b.FilenamePatterns) == 0": len(b.FilenamePatterns) == 0,
+		"b.GetPackageDir == nil": b.GetPackageDir == nil,
+		"b.Search == nil": b.Search == nil,
+		"b.Info == nil": b.Info == nil,
+		"b.Add == nil": b.Add == nil,
+		"b.Remove == nil": b.Remove == nil,
 		// The lock method should be unimplemented if
 		// and only if builds are not reproducible.
-		((b.Lock == nil) != b.QuirksIsNotReproducible()) ||
-		b.Install == nil ||
-		b.ListSpecfile == nil ||
-		b.ListLockfile == nil ||
+		"((b.Lock == nil) != b.QuirksIsNotReproducible())": ((b.Lock == nil) != b.QuirksIsNotReproducible()),
+		"b.Install == nil": b.Install == nil,
+		"b.ListSpecfile == nil": b.ListSpecfile == nil,
+		"b.ListLockfile == nil": b.ListLockfile == nil,
 		// If the backend isn't reproducible, then lock is
 		// unimplemented. So how could it also do
 		// installation?
-		b.QuirksDoesLockAlsoInstall() &&
-			b.QuirksIsNotReproducible() ||
+		"b.QuirksDoesLockAlsoInstall() && b.QuirksIsNotReproducible()": b.QuirksDoesLockAlsoInstall() && b.QuirksIsNotReproducible(),
 		// If you install, then you have to lock.
-		b.QuirksDoesAddRemoveAlsoInstall() &&
-			!b.QuirksDoesAddRemoveAlsoLock() {
-		util.Panicf("language backend %s is incomplete or invalid", b.Name)
+		"b.QuirksDoesAddRemoveAlsoInstall() && !b.QuirksDoesAddRemoveAlsoLock()": b.QuirksDoesAddRemoveAlsoInstall() && !b.QuirksDoesAddRemoveAlsoLock(),
+	}
+
+	reasons := []string{};
+	for reason, flag := range condition2flag {
+		if (flag) {
+			reasons = append(reasons, reason)
+		}
+	}
+
+	if (len(reasons) > 0) {
+		util.Panicf("language backend %s is incomplete or invalid: %s", b.Name, reasons)
 	}
 
 	if b.NormalizePackageName == nil {

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -316,27 +316,27 @@ type LanguageBackend struct {
 // validation.
 func (b *LanguageBackend) Setup() {
 	condition2flag := map[string]bool{
-		"b.Name == \"\"": b.Name == "",
-		"b.Specfile == \"\"": b.Specfile == "",
-		"b.Lockfile == \"\"": b.Lockfile == "",
-		"len(b.FilenamePatterns) == 0": len(b.FilenamePatterns) == 0,
-		"b.GetPackageDir == nil": b.GetPackageDir == nil,
-		"b.Search == nil": b.Search == nil,
-		"b.Info == nil": b.Info == nil,
-		"b.Add == nil": b.Add == nil,
-		"b.Remove == nil": b.Remove == nil,
+		"missing name": b.Name == "",
+		"missing specfile": b.Specfile == "",
+		"missing lockfile": b.Lockfile == "",
+		"need at least 1 filename pattern": len(b.FilenamePatterns) == 0,
+		"missing package dir": b.GetPackageDir == nil,
+		"missing Search": b.Search == nil,
+		"missing Info": b.Info == nil,
+		"missing Add": b.Add == nil,
+		"missing Remove": b.Remove == nil,
 		// The lock method should be unimplemented if
 		// and only if builds are not reproducible.
-		"((b.Lock == nil) != b.QuirksIsNotReproducible())": ((b.Lock == nil) != b.QuirksIsNotReproducible()),
-		"b.Install == nil": b.Install == nil,
-		"b.ListSpecfile == nil": b.ListSpecfile == nil,
-		"b.ListLockfile == nil": b.ListLockfile == nil,
+		"either implement Lock or mark QuirksIsNotReproducible": ((b.Lock == nil) != b.QuirksIsNotReproducible()),
+		"missing install": b.Install == nil,
+		"missing ListSpecfile": b.ListSpecfile == nil,
+		"missing ListLockfile": b.ListLockfile == nil,
 		// If the backend isn't reproducible, then lock is
 		// unimplemented. So how could it also do
 		// installation?
-		"b.QuirksDoesLockAlsoInstall() && b.QuirksIsNotReproducible()": b.QuirksDoesLockAlsoInstall() && b.QuirksIsNotReproducible(),
+		"Lock installs, but is not implemented": b.QuirksDoesLockAlsoInstall() && b.QuirksIsNotReproducible(),
 		// If you install, then you have to lock.
-		"b.QuirksDoesAddRemoveAlsoInstall() && !b.QuirksDoesAddRemoveAlsoLock()": b.QuirksDoesAddRemoveAlsoInstall() && !b.QuirksDoesAddRemoveAlsoLock(),
+		"Add and Remove install, so they must also Lock": b.QuirksDoesAddRemoveAlsoInstall() && !b.QuirksDoesAddRemoveAlsoLock(),
 	}
 
 	reasons := []string{};

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -316,19 +316,19 @@ type LanguageBackend struct {
 // validation.
 func (b *LanguageBackend) Setup() {
 	condition2flag := map[string]bool{
-		"missing name": b.Name == "",
-		"missing specfile": b.Specfile == "",
-		"missing lockfile": b.Lockfile == "",
+		"missing name":                     b.Name == "",
+		"missing specfile":                 b.Specfile == "",
+		"missing lockfile":                 b.Lockfile == "",
 		"need at least 1 filename pattern": len(b.FilenamePatterns) == 0,
-		"missing package dir": b.GetPackageDir == nil,
-		"missing Search": b.Search == nil,
-		"missing Info": b.Info == nil,
-		"missing Add": b.Add == nil,
-		"missing Remove": b.Remove == nil,
+		"missing package dir":              b.GetPackageDir == nil,
+		"missing Search":                   b.Search == nil,
+		"missing Info":                     b.Info == nil,
+		"missing Add":                      b.Add == nil,
+		"missing Remove":                   b.Remove == nil,
 		// The lock method should be unimplemented if
 		// and only if builds are not reproducible.
 		"either implement Lock or mark QuirksIsNotReproducible": ((b.Lock == nil) != b.QuirksIsNotReproducible()),
-		"missing install": b.Install == nil,
+		"missing install":      b.Install == nil,
 		"missing ListSpecfile": b.ListSpecfile == nil,
 		"missing ListLockfile": b.ListLockfile == nil,
 		// If the backend isn't reproducible, then lock is
@@ -339,14 +339,14 @@ func (b *LanguageBackend) Setup() {
 		"Add and Remove install, so they must also Lock": b.QuirksDoesAddRemoveAlsoInstall() && !b.QuirksDoesAddRemoveAlsoLock(),
 	}
 
-	reasons := []string{};
+	reasons := []string{}
 	for reason, flag := range condition2flag {
-		if (flag) {
+		if flag {
 			reasons = append(reasons, reason)
 		}
 	}
 
-	if (len(reasons) > 0) {
+	if len(reasons) > 0 {
 		util.Panicf("language backend %s is incomplete or invalid: %s", b.Name, reasons)
 	}
 

--- a/internal/backends/backends.go
+++ b/internal/backends/backends.go
@@ -8,6 +8,7 @@ import (
 	"github.com/replit/upm/internal/api"
 	"github.com/replit/upm/internal/backends/dart"
 	"github.com/replit/upm/internal/backends/elisp"
+	"github.com/replit/upm/internal/backends/java"
 	"github.com/replit/upm/internal/backends/nodejs"
 	"github.com/replit/upm/internal/backends/python"
 	"github.com/replit/upm/internal/backends/ruby"
@@ -27,6 +28,7 @@ var languageBackends = []api.LanguageBackend{
 	ruby.RubyBackend,
 	elisp.ElispBackend,
 	dart.DartPubBackend,
+	java.JavaBackend,
 }
 
 // matchesLanguage checks if a language backend matches a value for

--- a/internal/backends/java/java.go
+++ b/internal/backends/java/java.go
@@ -3,6 +3,7 @@ package java
 
 import (
 	"encoding/xml"
+  "fmt"
 	"io/ioutil"
   "os"
 	"regexp"
@@ -71,8 +72,20 @@ var JavaBackend = api.LanguageBackend{
 		return "target/dependency"
 	},
 	Search: func(query string) []api.PkgInfo {
-		var results []api.PkgInfo
-		return results
+    searchDocs, err := Search(query)
+    if err != nil {
+      util.Log("error searching maven %s", err)
+      return []api.PkgInfo{}
+    }
+    pkgInfos := []api.PkgInfo{}
+    for _, searchDoc := range(searchDocs) {
+      pkgInfo := api.PkgInfo{
+        Name: fmt.Sprintf("%s %s", searchDoc.Group, searchDoc.Artifact),
+        Version: searchDoc.Version,
+      }
+      pkgInfos = append(pkgInfos, pkgInfo)
+    }
+    return pkgInfos
 	},
 	Info: func(name api.PkgName) api.PkgInfo {
 		return api.PkgInfo{}

--- a/internal/backends/java/java.go
+++ b/internal/backends/java/java.go
@@ -88,7 +88,9 @@ var JavaBackend = api.LanguageBackend{
     return pkgInfos
 	},
 	Info: func(name api.PkgName) api.PkgInfo {
-		return api.PkgInfo{}
+		return api.PkgInfo{
+      Name: string(name),
+    }
 	},
 	Add: func(pkgs map[api.PkgName]api.PkgSpec) {
 		project := readProjectOrMakeEmpty(pomdotxml)

--- a/internal/backends/java/java.go
+++ b/internal/backends/java/java.go
@@ -80,7 +80,7 @@ var JavaBackend = api.LanguageBackend{
     pkgInfos := []api.PkgInfo{}
     for _, searchDoc := range(searchDocs) {
       pkgInfo := api.PkgInfo{
-        Name: fmt.Sprintf("%s %s", searchDoc.Group, searchDoc.Artifact),
+        Name: fmt.Sprintf("%s:%s", searchDoc.Group, searchDoc.Artifact),
         Version: searchDoc.Version,
       }
       pkgInfos = append(pkgInfos, pkgInfo)

--- a/internal/backends/java/java.go
+++ b/internal/backends/java/java.go
@@ -216,12 +216,12 @@ var JavaBackend = api.LanguageBackend{
 			Name: string(name),
 		}
 	},
-	Add: addPackages,
+	Add:    addPackages,
 	Remove: removePackages,
 	Install: func() {
 		util.RunCmd([]string{"mvn", "dependency:copy-dependencies"})
 	},
 	ListSpecfile: listSpecfile,
 	ListLockfile: listLockfile,
-	Lock: func() {},
+	Lock:         func() {},
 }

--- a/internal/backends/java/java.go
+++ b/internal/backends/java/java.go
@@ -101,8 +101,7 @@ func addPackages(pkgs map[api.PkgName]api.PkgSpec) {
 				)
 			}
 			if len(searchDocs) == 0 {
-				util.Log("did not find a package %s:%s", groupId, artifactId)
-				return
+				util.Die("did not find a package %s:%s", groupId, artifactId)
 			}
 			searchDoc := searchDocs[0]
 			versionString = searchDoc.Version

--- a/internal/backends/java/java.go
+++ b/internal/backends/java/java.go
@@ -1,0 +1,73 @@
+// Package java provides a backend for Java using maven.
+package java
+
+import (
+	"github.com/replit/upm/internal/api"
+	"github.com/replit/upm/internal/util"
+)
+
+const hardcodedPom = `
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+ 
+  <groupId>com.mycompany.app</groupId>
+  <artifactId>my-app</artifactId>
+  <version>1.0-SNAPSHOT</version>
+ 
+<dependencies>
+	<dependency>
+		<groupId>com.google.guava</groupId>
+		<artifactId>guava</artifactId>
+		<version>28.2-jre</version>
+	</dependency>
+</dependencies>
+</project>
+`
+
+// javaPatterns is the FilenamePatterns value for JavaBackend.
+var javaPatterns = []string{"*.java"}
+
+// JavaBackend is the UPM language backend for Java using Maven.
+var JavaBackend = api.LanguageBackend{
+	Name:             "java-maven",
+	Specfile:         "pom.xml",
+	Lockfile:         "pom.xml",
+	FilenamePatterns: javaPatterns,
+	// Quirks:           api.QuirksNotReproducible,
+	GetPackageDir: func() string {
+		return "target/dependency"
+	},
+	Search: func(query string) []api.PkgInfo {
+		var results []api.PkgInfo
+		return results
+	},
+	Info: func(name api.PkgName) api.PkgInfo {
+		return api.PkgInfo{}
+	},
+	Add: func(pkgs map[api.PkgName]api.PkgSpec) {
+		contentsB := []byte(hardcodedPom)
+		util.ProgressMsg("write pom.xml")
+		util.TryWriteAtomic("pom.xml", contentsB)
+	},
+	Remove: func(pkgs map[api.PkgName]bool) {
+		contentsB := []byte(hardcodedPom)
+		util.ProgressMsg("write pom.xml")
+		util.TryWriteAtomic("pom.xml", contentsB)
+	},
+	Install: func() {
+		util.RunCmd([]string{"mvn", "dependency:copy-dependencies"})
+	},
+	ListSpecfile: func() map[api.PkgName]api.PkgSpec {
+		pkgs := map[api.PkgName]api.PkgSpec{}
+		return pkgs
+	},
+	ListLockfile: func() map[api.PkgName]api.PkgVersion {
+		pkgs := map[api.PkgName]api.PkgVersion{}
+		name := api.PkgName("guava")
+		version := api.PkgVersion("28.2-jre")
+		pkgs[name] = version
+		return pkgs
+	},
+	Lock: func(){},
+}

--- a/internal/backends/java/java.go
+++ b/internal/backends/java/java.go
@@ -107,13 +107,31 @@ var JavaBackend = api.LanguageBackend{
 			if nil == submatches {
 				util.Die("package name %s does not match groupid:artifactid pattern")
 			} else {
+        groupId := submatches[1]
+        artifactId := submatches[2]
         if _, ok := existingDependencies[pkgName]; ok {
           // this package is already in the lock file
         } else {
+          var versionString string
+          if pkgSpec == "" {
+            searchDocs, err := Search(fmt.Sprintf("g:%s AND a:%s", groupId, artifactId))
+            if err != nil {
+              util.Log("error searching maven for latest version of %s:%s: %s", groupId, artifactId, err)
+              return
+            }
+            if len(searchDocs) == 0 {
+              util.Log("did not find a package %s:%s", groupId, artifactId)
+              return
+            }
+            searchDoc := searchDocs[0]
+            versionString = searchDoc.Version
+          } else {
+            versionString = string(pkgSpec)
+          }
           dependency := Dependency{
             GroupId: submatches[1],
             ArtifactId: submatches[2],
-            Version: string(pkgSpec),
+            Version: versionString,
           }
           newDependencies = append(newDependencies, dependency)
         }

--- a/internal/backends/java/msch.go
+++ b/internal/backends/java/msch.go
@@ -1,0 +1,61 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2016 Fredy Wijaya
+// Search() function lightly edited by Dan Stowell for repl.it, February 2020
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package java
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/url"
+)
+
+const (
+	mavenURL string = "http://search.maven.org/solrsearch/select?q="
+)
+
+type SearchDoc struct {
+  Group    string `json:"g"`
+  Artifact string `json:"a"`
+  Version  string `json:"latestVersion"`
+}
+
+type SearchResult struct {
+	Response struct {
+		Docs []SearchDoc `json:"docs"`
+	} `json:"response"`
+}
+
+func Search(keyword string) ([]SearchDoc, error) {
+	res, err := http.Get(mavenURL + url.QueryEscape(keyword))
+	if err != nil {
+		return []SearchDoc{}, err
+	}
+	defer res.Body.Close()
+	decoder := json.NewDecoder(res.Body)
+	var searchResult SearchResult
+	err = decoder.Decode(&searchResult)
+	if err != nil {
+		return []SearchDoc{}, err
+	}
+  return searchResult.Response.Docs, nil
+}

--- a/internal/backends/java/msch.go
+++ b/internal/backends/java/msch.go
@@ -27,6 +27,8 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/url"
+
+  "github.com/replit/upm/internal/util"
 )
 
 const (
@@ -46,7 +48,9 @@ type SearchResult struct {
 }
 
 func Search(keyword string) ([]SearchDoc, error) {
-	res, err := http.Get(mavenURL + url.QueryEscape(keyword))
+  searchUrl := mavenURL + url.QueryEscape(keyword)
+  util.Log("maven search ", searchUrl)
+	res, err := http.Get(searchUrl)
 	if err != nil {
 		return []SearchDoc{}, err
 	}

--- a/internal/backends/java/msch.go
+++ b/internal/backends/java/msch.go
@@ -27,8 +27,6 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/url"
-
-  "github.com/replit/upm/internal/util"
 )
 
 const (
@@ -49,7 +47,6 @@ type SearchResult struct {
 
 func Search(keyword string) ([]SearchDoc, error) {
   searchUrl := mavenURL + url.QueryEscape(keyword)
-  util.Log("maven search ", searchUrl)
 	res, err := http.Get(searchUrl)
 	if err != nil {
 		return []SearchDoc{}, err

--- a/internal/backends/java/msch.go
+++ b/internal/backends/java/msch.go
@@ -34,9 +34,9 @@ const (
 )
 
 type SearchDoc struct {
-  Group    string `json:"g"`
-  Artifact string `json:"a"`
-  Version  string `json:"latestVersion"`
+	Group    string `json:"g"`
+	Artifact string `json:"a"`
+	Version  string `json:"latestVersion"`
 }
 
 type SearchResult struct {
@@ -46,7 +46,7 @@ type SearchResult struct {
 }
 
 func Search(keyword string) ([]SearchDoc, error) {
-  searchUrl := mavenURL + url.QueryEscape(keyword)
+	searchUrl := mavenURL + url.QueryEscape(keyword)
 	res, err := http.Get(searchUrl)
 	if err != nil {
 		return []SearchDoc{}, err
@@ -58,5 +58,5 @@ func Search(keyword string) ([]SearchDoc, error) {
 	if err != nil {
 		return []SearchDoc{}, err
 	}
-  return searchResult.Response.Docs, nil
+	return searchResult.Response.Docs, nil
 }

--- a/scripts/docker-install-languages.bash
+++ b/scripts/docker-install-languages.bash
@@ -24,6 +24,7 @@ curl
 emacs-nox
 git
 jq
+maven
 nodejs
 npm
 python


### PR DESCRIPTION
This change adds a `java-maven` backend that can add, remove, and search packages from the Maven central repository.

TODOs:
- Have `upm -l java info <packagename>` return the package description if it exists.
- search will only return the latest version for a package. A package such as `com.google.guava:guava` has a `28.2-jre` and `28.2-android` latest version - it'd be nice to return multiple versions so that folks can add the correct one for their project.