### PR TITLE
node npm/yarn skip absolute modules

### DIFF
--- a/resources/nodejs/bare-imports.js
+++ b/resources/nodejs/bare-imports.js
@@ -171,6 +171,11 @@ async function commandLine(args) {
       continue;
     }
 
+    // Skip absolute modules.
+    if (module[0] === "/") {
+      continue;
+    }
+
     // Resolve "express/router" into just "express", but
     // "@types/express/router" into "@types/express".
     if (module[0] === "@") {


### PR DESCRIPTION
Why
===

modules with a leading slash are **probably** meant to be read off the
filesystem and shouldn't be included in upm's guess. Previously any imports like
`import '/mymodule'` would result in upm guessing the package `""` was required.