### PR TITLE
root flag to expand ignored paths

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -48,6 +48,7 @@ func DoCLI() {
 	var forceGuess bool
 	var all bool
 	var ignoredPackages []string
+	var ignoredPaths []string
 	var upgrade bool
 
 	cobra.EnableCommandSorting = false
@@ -69,7 +70,11 @@ func DoCLI() {
 	)
 	rootCmd.PersistentFlags().StringSliceVar(
 		&ignoredPackages, "ignored-packages", []string{},
-		"packages to ignore when guessing (comma-separated)",
+		"packages to ignore when guessing or adding (comma-separated)",
+	)
+	rootCmd.PersistentFlags().StringSliceVar(
+		&ignoredPaths, "ignored-paths", []string{},
+		"paths to ignore when guessing (comma-separated)",
 	)
 	rootCmd.PersistentFlags().BoolP(
 		"help", "h", false, "display command-line usage",
@@ -246,6 +251,7 @@ func DoCLI() {
 		Short: "Guess what packages are needed by your project",
 		Args:  cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
+			util.AddIngoredPaths(ignoredPaths)
 			runGuess(language, all, forceGuess, ignoredPackages)
 		},
 	}

--- a/internal/util/file.go
+++ b/internal/util/file.go
@@ -46,6 +46,11 @@ var IgnoredPaths = []string{
 	"venv",
 }
 
+// AddIngoredPaths globally appends to the IngoredPaths list.
+func AddIngoredPaths(paths []string) {
+	IgnoredPaths = append(IgnoredPaths, paths...)
+}
+
 // TryWriteAtomic tries to write contents to filename atomically,
 // retrying non-atomically if it can't. If both attempts fail,
 // TryWriteAtomic terminates the process.


### PR DESCRIPTION
why
===

Some frameworks/templates could be made a bit faster by explicitly ignoring
known paths from upm's guess. These paths aren't general enough to apply to all
languages or any specific language in all cases. To give the end user (who
hopefully knows best) more control we'll add an ignored paths flag.