### PR TITLE
handle pom-type dependencies

### DIFF
--- a/internal/backends/java/java.go
+++ b/internal/backends/java/java.go
@@ -141,7 +141,12 @@ func addPackages(pkgs map[api.PkgName]api.PkgSpec) {
 			continue
 		}
 
-		query := fmt.Sprintf("g:%s AND a:%s", groupId, artifactId)
+		var query string
+		if pkgSpec == "" {
+			query = fmt.Sprintf("g:%s AND a:%s", groupId, artifactId)
+		} else {
+			query = fmt.Sprintf("g:%s AND a:%s AND v:%s", groupId, artifactId, pkgSpec)
+		}
 		searchDocs, err := Search(query)
 		if err != nil {
 			util.Die(
@@ -152,7 +157,11 @@ func addPackages(pkgs map[api.PkgName]api.PkgSpec) {
 			)
 		}
 		if len(searchDocs) == 0 {
-			util.Die("did not find a package %s:%s", groupId, artifactId)
+			if pkgSpec == "" {
+				util.Die("did not find a package %s:%s", groupId, artifactId)
+			} else {
+				util.Die("did not find a package %s:%s:%s", groupId, artifactId, pkgSpec)
+			}
 		}
 		searchDoc := searchDocs[0]
 

--- a/internal/backends/java/java.go
+++ b/internal/backends/java/java.go
@@ -13,10 +13,11 @@ import (
 )
 
 type Dependency struct {
-	XMLName    xml.Name `xml:"dependency"`
-	GroupId    string   `xml:"groupId"`
-	ArtifactId string   `xml:"artifactId"`
-	Version    string   `xml:"version"`
+	XMLName     xml.Name `xml:"dependency"`
+	GroupId     string   `xml:"groupId"`
+	ArtifactId  string   `xml:"artifactId"`
+	Version     string   `xml:"version"`
+	PackageType string   `xml:"type"`
 }
 
 type DynamicDependency struct {
@@ -140,30 +141,40 @@ func addPackages(pkgs map[api.PkgName]api.PkgSpec) {
 			continue
 		}
 
+		query := fmt.Sprintf("g:%s AND a:%s", groupId, artifactId)
+		searchDocs, err := Search(query)
+		if err != nil {
+			util.Die(
+				"error searching maven for latest version of %s:%s: %s",
+				groupId,
+				artifactId,
+				err,
+			)
+		}
+		if len(searchDocs) == 0 {
+			util.Die("did not find a package %s:%s", groupId, artifactId)
+		}
+		searchDoc := searchDocs[0]
+
 		var versionString string
 		if pkgSpec == "" {
-			query := fmt.Sprintf("g:%s AND a:%s", groupId, artifactId)
-			searchDocs, err := Search(query)
-			if err != nil {
-				util.Die(
-					"error searching maven for latest version of %s:%s: %s",
-					groupId,
-					artifactId,
-					err,
-				)
-			}
-			if len(searchDocs) == 0 {
-				util.Die("did not find a package %s:%s", groupId, artifactId)
-			}
-			searchDoc := searchDocs[0]
 			versionString = searchDoc.Version
 		} else {
 			versionString = string(pkgSpec)
 		}
+
+		var packageType string
+		if searchDoc.PackageType == "pom" {
+			packageType = "pom"
+		} else {
+			packageType = "jar"
+		}
+
 		dependency := Dependency{
-			GroupId:    submatches[1],
-			ArtifactId: submatches[2],
-			Version:    versionString,
+			GroupId:     submatches[1],
+			ArtifactId:  submatches[2],
+			Version:     versionString,
+			PackageType: packageType,
 		}
 		newDependencies = append(newDependencies, dependency)
 

--- a/internal/backends/java/msch.go
+++ b/internal/backends/java/msch.go
@@ -34,9 +34,10 @@ const (
 )
 
 type SearchDoc struct {
-	Group    string `json:"g"`
-	Artifact string `json:"a"`
-	Version  string `json:"latestVersion"`
+	Group       string `json:"g"`
+	Artifact    string `json:"a"`
+	Version     string `json:"latestVersion"`
+	PackageType string `json:"p"`
 }
 
 type SearchResult struct {


### PR DESCRIPTION
Most Maven artifacts are jar files. Some are pom files that point to other artifacts. By default Maven treats any `<dependency>` as pointing to a jar. This works most of the time, but will break for pom artifacts, like Javacord:

```
<dependency>
    <groupId>org.javacord</groupId>
    <artifactId>javacord</artifactId>
    <version>3.0.5</version>
    <type>pom</type>
</dependency>
```

When adding a package now, we always search the Maven repository for the package to fetch its `<type>`.

Also, as I wrote this, I realized that we _should_ search for the specified version if a user passes in a `pkgSpec` to `upm add`. So I fixed up the `add` path to do that.