### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "go"
+run = ""

--- a/.replit
+++ b/.replit
@@ -1,2 +1,2 @@
 language = "go"
-run = ""
+run = "make"

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 ![upm](https://amasad.me/public/images/long.png)
 [![GoDoc](https://godoc.org/github.com/replit/upm?status.svg)](https://godoc.org/github.com/replit/upm)
+[![Run on Repl.it](https://repl.it/badge/github/replit/upm)](https://repl.it/github/replit/upm)
 
 UPM is the **Universal Package Manager**. It allows you to manage
 packages for any (supported) programming language through the same


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).