### PR TITLE
Ignore loaders and absolute paths

### DIFF
--- a/internal/backends/nodejs/grab.go
+++ b/internal/backends/nodejs/grab.go
@@ -164,9 +164,27 @@ func guessBareImports() map[api.PkgName]bool {
 				continue
 			}
 
+			// Skip empty imports
+			if mod == "" {
+				continue
+			}
+
+			// Skip absolute imports
+			if mod[0] == '/' {
+				continue
+			}
+
+			// Skip relative imports
 			if mod[0] == '.' {
 				continue
 			}
+
+			// Skip script loaders
+			if strings.Contains(mod, "!") {
+				continue
+			}
+
+			// Handle scoped modules
 			if mod[0] == '@' {
 				parts := strings.Split(mod, "/")
 				if len(parts) < 2 {


### PR DESCRIPTION
Webpack allows users to add `!` to load arbitrary files and this should be ignored by upm. 
More generally I ported the code from here https://github.com/replit/upm/blob/c9627d248a515cbe594950227afd5f1b2600b867/resources/nodejs/bare-imports.js#L160-L177