### PR TITLE
create virtualenv under .upm for python

### DIFF
--- a/internal/util/command.go
+++ b/internal/util/command.go
@@ -33,6 +33,20 @@ func RunCmd(cmd []string) {
 	}
 }
 
+// RunCmdWithEnv prints and runs the given command with the passed-in
+// environment variables (plus upm's environment), exiting the process on
+// error or command failure. Stdout and stderr go to the terminal.
+func RunCmdWithEnv(cmd []string, env []string) {
+	ProgressMsg(quoteCmd(cmd))
+	command := exec.Command(cmd[0], cmd[1:]...)
+	command.Stdout = os.Stderr
+	command.Stderr = os.Stderr
+	command.Env = append(os.Environ(), env...)
+	if err := command.Run(); err != nil {
+		Die("%s", err)
+	}
+}
+
 // GetCmdOutput prints and runs the given command, returning its
 // stdout as a string. Stderr goes to the terminal. GetCmdOutput exits
 // the process on error or command failure.

--- a/scripts/docker-install-languages.bash
+++ b/scripts/docker-install-languages.bash
@@ -44,8 +44,8 @@ apt-get update
 apt-get install -y $packages
 rm -rf /var/lib/apt/lists/*
 
-pip2 --disable-pip-version-check install poetry
-pip3 --disable-pip-version-check install poetry
+pip2 --disable-pip-version-check install poetry==1.0.5 virtualenv
+pip3 --disable-pip-version-check install poetry==1.0.5 virtualenv
 curl -fsSL https://raw.githubusercontent.com/cask/cask/master/go | python3
 ln -s "$HOME/.cask/bin/cask" /usr/local/bin/
 


### PR DESCRIPTION
The problem I'm trying to solve: in a repl, I'd like to create a virtualenv in the working directory only when someone adds a python package.

upm knows when it's adding a python package, so I figured it could create the virtualenv at `.upm/virtualenvs/python(2|3)/`! If you don't want upm to create a virtualenv, you can point to an existing virtualenv with the `VIRTUAL_ENV` env var.

If creating virtualenvs falls outside upm's remit, I'm happy to move this logic elsewhere!

This change also explicitly installs poetry 1.0.5 (we've been implicitly pulling that version of poetry for some time).