### PR TITLE
Allow python comments to hint UPM

### DIFF
--- a/internal/backends/python/python.go
+++ b/internal/backends/python/python.go
@@ -394,10 +394,17 @@ func guess(python string) (map[api.PkgName]bool, bool) {
 			continue
 		}
 
-		pkg, ok := moduleToPypiPackage[modname]
-		if ok {
+		if modname[0] == '"' && modname[len(modname) - 1] == '"' {
+			pkg := modname[1:len(modname) - 1]
+
 			name := api.PkgName(pkg)
 			pkgs[normalizePackageName(name)] = true
+		} else {
+			pkg, ok := moduleToPypiPackage[modname]
+			if ok {
+				name := api.PkgName(pkg)
+				pkgs[normalizePackageName(name)] = true
+			}
 		}
 	}
 

--- a/internal/backends/python/python.go
+++ b/internal/backends/python/python.go
@@ -62,6 +62,12 @@ type poetryLock struct {
 	} `json:"package"`
 }
 
+// moduleMetadata represents the information that could be associated with
+// a module using a #upm pragma
+type modulePragmas struct {
+	Package string `json:"package"`
+}
+
 // normalizeSpec returns the version string from a Poetry spec, or the
 // empty string. The Poetry spec may be either a string or a
 // map[string]interface{} with a "version" key that is a string. If
@@ -365,8 +371,8 @@ func guess(python string) (map[api.PkgName]bool, bool) {
 	})
 
 	var output struct {
-		Imports []string `json:"imports"`
-		Success bool     `json:"success"`
+		Imports map[string]modulePragmas `json:"imports"`
+		Success bool                     `json:"success"`
 	}
 
 	if err := json.Unmarshal(outputB, &output); err != nil {
@@ -388,18 +394,19 @@ func guess(python string) (map[api.PkgName]bool, bool) {
 
 	pkgs := map[api.PkgName]bool{}
 
-	for _, modname := range output.Imports {
+	for modname, pragmas := range output.Imports {
 		// provided by an existing package or perhaps by the system
 		if availMods[modname] {
 			continue
 		}
 
-		if modname[0] == '"' && modname[len(modname) - 1] == '"' {
-			pkg := modname[1:len(modname) - 1]
-
-			name := api.PkgName(pkg)
+		// If this module has a package pragma, use that
+		if pragmas.Package != ""{
+			name := api.PkgName(pragmas.Package)
 			pkgs[normalizePackageName(name)] = true
+
 		} else {
+			// Otherwise, try and look it up in Pypi
 			pkg, ok := moduleToPypiPackage[modname]
 			if ok {
 				name := api.PkgName(pkg)

--- a/resources/python/pipreqs.py
+++ b/resources/python/pipreqs.py
@@ -67,7 +67,7 @@ def get_all_imports(
                         # If this line ends in a upm pragma, don't process it
                         m = re.match('^.*#upm\\((.*)\\).*$', line)
                         if m:
-                            raw_imports.add(m.group(1))
+                            raw_imports.add('"' + m.group(1) + '"')
                             continue
                     except AttributeError:
                         pass


### PR DESCRIPTION
UPM has difficulty resolving python packages when multiple packages provide the same module. Adds the ability to mark an import line with `#upm(package_name)` to override the package guess and directly specify the package that should be used.

```python
import twitter #upm package(python-twitter)

...
```