### PR TITLE
Support passing project name to backend

### DIFF
--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -206,14 +206,6 @@ type LanguageBackend struct {
 	// This field is mandatory.
 	Info func(PkgName) PkgInfo
 
-	// Initalizes the specfile. If the language backend supports
-	// setting a project name, it will use the name specified. An
-	// empty name will use the default name as decided by the language
-	// backend.
-	//
-	// This field is optional.
-	Init func(project_name string)
-
 	// Add packages to the specfile. The map is guaranteed to have
 	// at least one package, and all of the packages are
 	// guaranteed to not already be in the specfile (according to
@@ -221,14 +213,18 @@ type LanguageBackend struct {
 	// already. The specs may be empty, in which case default
 	// specs should be generated (for example, specifying the
 	// latest version or newer). This method must create the
-	// specfile if it does not exist already.
+	// specfile if it does not exist already. Additional
+	// information needed to create the specfile can be passed
+	// as well. If a significant amount of additional info is
+	// required for initalizing specfiles, we can break that out
+	// to a seperate step.
 	//
 	// If QuirksAddRemoveAlsoInstalls, then also lock and install.
 	// In this case this method must also create the lockfile if
 	// it does not exist already.
 	//
 	// This field is mandatory.
-	Add func(map[PkgName]PkgSpec)
+	Add func(map[PkgName]PkgSpec, string)
 
 	// Remove packages from the specfile. The map is guaranteed to
 	// have at least one package, and all of the packages are

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -206,6 +206,14 @@ type LanguageBackend struct {
 	// This field is mandatory.
 	Info func(PkgName) PkgInfo
 
+	// Initalizes the specfile. If the language backend supports
+	// setting a project name, it will use the name specified. An
+	// empty name will use the default name as decided by the language
+	// backend.
+	//
+	// This field is optional.
+	Init func(project_name string)
+
 	// Add packages to the specfile. The map is guaranteed to have
 	// at least one package, and all of the packages are
 	// guaranteed to not already be in the specfile (according to

--- a/internal/backends/dart/dart.go
+++ b/internal/backends/dart/dart.go
@@ -248,7 +248,7 @@ func readSpecFile() dartPubspecYaml {
 	return specs
 }
 
-func dartAdd(pkgs map[api.PkgName]api.PkgSpec) {
+func dartAdd(pkgs map[api.PkgName]api.PkgSpec, projectName string) {
 	if !util.Exists("pubspec.yaml") {
 		createSpecFile()
 	}

--- a/internal/backends/elisp/elisp.go
+++ b/internal/backends/elisp/elisp.go
@@ -75,7 +75,7 @@ var ElispBackend = api.LanguageBackend{
 		}
 		return info
 	},
-	Add: func(pkgs map[api.PkgName]api.PkgSpec) {
+	Add: func(pkgs map[api.PkgName]api.PkgSpec, projectName string) {
 		contentsB, err := ioutil.ReadFile("Cask")
 		var contents string
 		if os.IsNotExist(err) {

--- a/internal/backends/java/java.go
+++ b/internal/backends/java/java.go
@@ -113,7 +113,7 @@ func readProjectOrMakeEmpty(path string) Project {
 
 const pomdotxml = "pom.xml"
 
-func addPackages(pkgs map[api.PkgName]api.PkgSpec) {
+func addPackages(pkgs map[api.PkgName]api.PkgSpec, projectName string) {
 	project := readProjectOrMakeEmpty(pomdotxml)
 	existingDependencies := map[api.PkgName]api.PkgVersion{}
 	for _, dependency := range project.Dependencies {

--- a/internal/backends/nodejs/nodejs.go
+++ b/internal/backends/nodejs/nodejs.go
@@ -256,7 +256,7 @@ var NodejsYarnBackend = api.LanguageBackend{
 	},
 	Search: nodejsSearch,
 	Info:   nodejsInfo,
-	Add: func(pkgs map[api.PkgName]api.PkgSpec) {
+	Add: func(pkgs map[api.PkgName]api.PkgSpec, projectName string) {
 		if !util.Exists("package.json") {
 			util.RunCmd([]string{"yarn", "init", "-y"})
 		}
@@ -318,7 +318,7 @@ var NodejsNPMBackend = api.LanguageBackend{
 	},
 	Search: nodejsSearch,
 	Info:   nodejsInfo,
-	Add: func(pkgs map[api.PkgName]api.PkgSpec) {
+	Add: func(pkgs map[api.PkgName]api.PkgSpec, projectName string) {
 		if !util.Exists("package.json") {
 			util.RunCmd([]string{"npm", "init", "-y"})
 		}

--- a/internal/backends/python/python.go
+++ b/internal/backends/python/python.go
@@ -248,18 +248,18 @@ func pythonMakeBackend(name string, python string) api.LanguageBackend {
 
 			return info
 		},
-		Init: func(name string) {
+		Add: func(pkgs map[api.PkgName]api.PkgSpec, projectName string) {
+			// Initalize the specfile if it doesnt exist
 			if !util.Exists("pyproject.toml") {
 				cmd := []string{python, "-m", "poetry", "init", "--no-interaction"}
 
-				if name != "" {
-					cmd = append(cmd, "--name", name)
+				if projectName != "" {
+					cmd = append(cmd, "--name", projectName)
 				}
 
 				util.RunCmd(cmd)
 			}
-		},
-		Add: func(pkgs map[api.PkgName]api.PkgSpec) {
+
 			cmd := []string{python, "-m", "poetry", "add"}
 			for name, spec := range pkgs {
 				name := string(name)

--- a/internal/backends/python/python.go
+++ b/internal/backends/python/python.go
@@ -248,10 +248,18 @@ func pythonMakeBackend(name string, python string) api.LanguageBackend {
 
 			return info
 		},
-		Add: func(pkgs map[api.PkgName]api.PkgSpec) {
+		Init: func(name string) {
 			if !util.Exists("pyproject.toml") {
-				util.RunCmd([]string{python, "-m", "poetry", "init", "--no-interaction"})
+				cmd := []string{python, "-m", "poetry", "init", "--no-interaction"}
+
+				if name != "" {
+					cmd = append(cmd, "--name", name)
+				}
+
+				util.RunCmd(cmd)
 			}
+		},
+		Add: func(pkgs map[api.PkgName]api.PkgSpec) {
 			cmd := []string{python, "-m", "poetry", "add"}
 			for name, spec := range pkgs {
 				name := string(name)

--- a/internal/backends/rlang/rlang.go
+++ b/internal/backends/rlang/rlang.go
@@ -110,7 +110,7 @@ var RlangBackend = api.LanguageBackend{
 
 		return api.PkgInfo{}
 	},
-	Add: func(packages map[api.PkgName]api.PkgSpec) {
+	Add: func(packages map[api.PkgName]api.PkgSpec, projectName string) {
 		for name, info := range packages {
 			RAdd(RPackage{
 				Name:    string(name),

--- a/internal/backends/ruby/ruby.go
+++ b/internal/backends/ruby/ruby.go
@@ -168,7 +168,7 @@ var RubyBackend = api.LanguageBackend{
 			Dependencies:     deps,
 		}
 	},
-	Add: func(pkgs map[api.PkgName]api.PkgSpec) {
+	Add: func(pkgs map[api.PkgName]api.PkgSpec, projectName string) {
 		if !util.Exists("Gemfile") {
 			util.RunCmd([]string{"bundle", "init"})
 		}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -50,6 +50,7 @@ func DoCLI() {
 	var ignoredPackages []string
 	var ignoredPaths []string
 	var upgrade bool
+	var name string
 
 	cobra.EnableCommandSorting = false
 
@@ -81,6 +82,9 @@ func DoCLI() {
 	)
 	rootCmd.PersistentFlags().BoolP(
 		"version", "v", false, "display command version",
+	)
+	rootCmd.PersistentFlags().StringVarP(
+		&name, "name", "n", "", "specify project name",
 	)
 
 	cmdWhichLanguage := &cobra.Command{
@@ -144,7 +148,7 @@ func DoCLI() {
 		Run: func(cmd *cobra.Command, args []string) {
 			pkgSpecStrs := args
 			runAdd(language, pkgSpecStrs, upgrade, guess, forceGuess,
-				ignoredPackages, forceLock, forceInstall)
+				ignoredPackages, forceLock, forceInstall, name)
 		},
 	}
 	cmdAdd.Flags().SortFlags = false

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -83,9 +83,6 @@ func DoCLI() {
 	rootCmd.PersistentFlags().BoolP(
 		"version", "v", false, "display command version",
 	)
-	rootCmd.PersistentFlags().StringVarP(
-		&name, "name", "n", "", "specify project name",
-	)
 
 	cmdWhichLanguage := &cobra.Command{
 		Use:   "which-language",
@@ -166,6 +163,9 @@ func DoCLI() {
 	)
 	cmdAdd.Flags().BoolVar(
 		&forceGuess, "force-guess", false, "bypass cache when guessing dependencies",
+	)
+	cmdAdd.Flags().StringVarP(
+		&name, "name", "n", "", "specify project name",
 	)
 	rootCmd.AddCommand(cmdAdd)
 

--- a/internal/cli/cmds.go
+++ b/internal/cli/cmds.go
@@ -277,12 +277,7 @@ func runAdd(
 			pkgs[nameAndSpec.name] = nameAndSpec.spec
 		}
 
-		// Init is an optional function, skip if not defined
-		if b.Init != nil {
-			b.Init(name)
-		}
-
-		b.Add(pkgs)
+		b.Add(pkgs, name)
 	}
 
 	if len(normPkgs) == 0 || b.QuirksDoesAddRemoveNotAlsoLock() {

--- a/internal/cli/cmds.go
+++ b/internal/cli/cmds.go
@@ -214,7 +214,7 @@ type pkgNameAndSpec struct {
 func runAdd(
 	language string, args []string, upgrade bool,
 	guess bool, forceGuess bool, ignoredPackages []string,
-	forceLock bool, forceInstall bool) {
+	forceLock bool, forceInstall bool, name string) {
 
 	b := backends.GetBackend(language)
 
@@ -276,6 +276,12 @@ func runAdd(
 		for _, nameAndSpec := range normPkgs {
 			pkgs[nameAndSpec.name] = nameAndSpec.spec
 		}
+
+		// Init is an optional function, skip if not defined
+		if b.Init != nil {
+			b.Init(name)
+		}
+
 		b.Add(pkgs)
 	}
 


### PR DESCRIPTION
Poetry cannot install packages with the same name as the project. UPM initializes the specfile automatically and does so with whatever the default project name is. Using poetry, the default project name is the name of the root directory.

This causes an error when the root directory of a project has the same name as a package that should be installed. This PR adds a `--name` flag that can be passed to upm to specify what to use as the project name in the specfile. If `--name` is not specified, the default project name is used as determined by the language backend.