### PR TITLE
Haskell(stack) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ machine-parseable specfile and lockfile listing.
 | elisp-cask            | yes  | yes   | yes   |
 | dart-pub.dev          | yes  | yes   |       |
 | rlang                 | yes  | yes   |       |
+| haskell-stack         | yes  | yes   |       |
 
 ## Installation
 

--- a/go.sum
+++ b/go.sum
@@ -50,6 +50,7 @@ github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9 h1:mKdxBk7AujPs8kU4m80U72y/zjbZ3UcXC7dClwKbUI0=
 golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550 h1:ObdrDkeb4kJdCP557AjRjq69pTHfNouLtWZG7j9rPN8=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/mod v0.2.0 h1:KU7oHjnv3XNWfa5COkzUifxZmxp1TyI7ImMXqFxLwvQ=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
@@ -61,6 +62,7 @@ golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sys v0.0.0-20181205085412-a5c9d58dba9a h1:1n5lsVfiQW3yfsRGu98756EH1YthsFqr/5mxHduZW2A=
 golang.org/x/sys v0.0.0-20181205085412-a5c9d58dba9a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190412213103-97732733099d h1:+R4KGOnez64A81RvjARKc4UT5/tI9ujCIVX+P5KiHuI=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/internal/backends/backends.go
+++ b/internal/backends/backends.go
@@ -13,6 +13,7 @@ import (
 	"github.com/replit/upm/internal/backends/python"
 	"github.com/replit/upm/internal/backends/rlang"
 	"github.com/replit/upm/internal/backends/ruby"
+	"github.com/replit/upm/internal/backends/haskell"
 	"github.com/replit/upm/internal/util"
 )
 
@@ -31,6 +32,7 @@ var languageBackends = []api.LanguageBackend{
 	dart.DartPubBackend,
 	java.JavaBackend,
 	rlang.RlangBackend,
+	haskell.HaskellBackend
 }
 
 // matchesLanguage checks if a language backend matches a value for

--- a/internal/backends/backends.go
+++ b/internal/backends/backends.go
@@ -32,7 +32,7 @@ var languageBackends = []api.LanguageBackend{
 	dart.DartPubBackend,
 	java.JavaBackend,
 	rlang.RlangBackend,
-	haskell.HaskellBackend
+	haskell.HaskellBackend,
 }
 
 // matchesLanguage checks if a language backend matches a value for

--- a/internal/backends/haskell/haskell.go
+++ b/internal/backends/haskell/haskell.go
@@ -1,0 +1,62 @@
+package haskell
+
+import (
+    "encoding/json"
+    "net/http"
+    "io/ioutil"
+    "github.com/replit/upm/internal/api"
+)
+
+var HaskellBackend = api.LanguageBackend {
+    Name:                "haskell-stack",
+    Specfile:            "package.yaml",
+    Lockfile:            "stack.yaml.lock",
+    FileNamePatterns:    []string{"*.hs"},
+    Quirks:              api.QuirksLockAlsoInstalls,
+    GetPackageDir:       func () string {return ".stack-work"},
+    // note : Stack actually uses two package directories:
+    // ~/.stack/ for stackage packages and .stack-work for others
+    Search:              searchFunction,
+    Info:                infoFunction
+
+}
+
+type hoogleModuleOrPackage struct{
+    url string
+    name string
+}
+type hoogleResult struct{
+    url string
+    module hoogleModuleOrPackage
+    hpackage hoogleModuleOrPackage `json:"package"`
+    // because package is a keyword
+    item string
+    htype string `json:"type"`
+    // type is also a keyword
+    docs string
+}
+
+func searchFunction(query string) []api.PkgInfo {
+    // search stackage[hoogle] first
+    if res, err:= http.Get("https://hoogle.haskell.org/?mode=json&format=text&hoogle="+query+"%20is%3Apackage"), err!= nil {
+        panic(err)
+    }
+    var results []hoogleResult
+    data, _ := ioutil.Readall(res.Body)
+    res.Body.Close()
+    json.Unmarshal(data, &results)
+    finresults = []api.PkgInfo{}
+    for result := range results{        
+        finresults = append(finresults, api.PkgInfo{
+            Name : result.item[8:]
+            // result.item is of the form "package packagename"
+            Description : result.docs
+            
+            
+
+
+
+    
+}
+    
+     

--- a/internal/backends/haskell/haskell.go
+++ b/internal/backends/haskell/haskell.go
@@ -15,66 +15,77 @@ var HaskellBackend = api.LanguageBackend {
     Name:                "haskell-stack",
     Specfile:            "package.yaml",
     Lockfile:            "stack.yaml.lock",
-    FileNamePatterns:    []string{"*.hs"},
+    // also present: a .cabal and stack.yaml
+    FilenamePatterns:    []string{"*.hs"},
     Quirks:              api.QuirksLockAlsoInstalls,
-    GetPackageDir:       func () string {return ".stack-work"},
+    GetPackageDir:       func () string {
+        return ".stack-work"
+    },
     // note : Stack actually uses two package directories:
     // ~/.stack/ for stackage packages and .stack-work for others
-    Search:              searchFunction,
-    Info:                infoFunction,
+    Search:              func(q string) []api.PkgInfo {
+        return searchFunction(q,false)
+    },
+    Info:                func(i api.PkgName) api.PkgInfo {
+        return searchFunction(string(i),true)[0]
+    },
+    Add:                 func(map[api.PkgName]api.PkgSpec, string){},
+    Remove:              func(map[api.PkgName]bool) {},
+    Lock:                util.NotImplemented,
+    Install:             util.NotImplemented,
+    ListSpecfile:        func()map[api.PkgName]api.PkgSpec{
+        return map[api.PkgName]api.PkgSpec{}
+    },
+    ListLockfile:        func()map[api.PkgName]api.PkgVersion{
+        return map[api.PkgName]api.PkgVersion{}
+    },
+    Guess:               func()(map[api.PkgName]bool,bool){
+        return map[api.PkgName]bool{},false
+    },
+
     
-
-
 }
 
-type hoogleModuleOrPackage struct{
-    url string
-    name string
-}
-type hoogleResult struct{
-    url string
-    module hoogleModuleOrPackage
-    hpackage hoogleModuleOrPackage `json:"package"`
-    // because package is a keyword
-    item string
-    htype string `json:"type"`
-    // type is also a keyword
-    docs string
-}
 
-func searchFunction(query string, indiv bool = false) []api.PkgInfo {
+
+func searchFunction(query string, indiv bool) []api.PkgInfo {
     // search stackage[hoogle] first
     res, err:= http.Get("https://hoogle.haskell.org/?mode=json&format=text&hoogle="+url.QueryEscape(query)+"%20is%3Apackage")
     if err!= nil {
         util.Die("hoogle response:"+ err.Error())
     }
-    var results []hoogleResult
-    data, _ := ioutil.Readall(res.Body)
+    var results = []map[string]string{}
+    data, _ := ioutil.ReadAll(res.Body)
     res.Body.Close()
     json.Unmarshal(data, &results)
-    finresults = []api.PkgInfo{}
-    if indiv {results = [results[0]]} // so we can skip implementing the search function again
-    for result := range results{
-        getCabal, err := http.Get(result.url + "/src/" + result.item[8:] + ".cabal")
+    finresults := []api.PkgInfo{}
+    if indiv {results = results[:1]} // so we can skip implementing the search function again
+    for _,result := range results{
+        getCabal, err := http.Get(result["url"] + "/src/" + result["item"][8:] + ".cabal")
         if err!= nil {
             util.Die("hackage [cabal file] response:" + err.Error())
         }
         cabal, _ := ioutil.ReadAll(getCabal.Body)
-        cabalRegexp := regexp.MustCompile(`\n(\S+): +(.?)\n`)
+        getCabal.Body.Close()
+        cabalRegexp := regexp.MustCompile(`(\S+): +(.+)`)
         cabalDataSlice := cabalRegexp.FindAllSubmatch(cabal, -1)
         cabalData := make(map[string]string)
-        for s := range cabalDataSlice{
-            cabalData[string(s[0])] = string(s[1])
+        for _,s := range cabalDataSlice{
+            cabalData[string(s[1])] = string(s[2])
         }
-        var info api.PkgInfo{
-            Name:           result.item[8:]
-            Description:    strings.ReplaceAll(result.docs, "\n", " ")
-            Version:        cabalData["version"]
-            HomePageURL:    result.url 
-            SoourceCodeURL: cabalData["homepage"] //yes, homepage tends to be the github page 
-            BugTrackerURL:  cabalData["bug-reports"]
-            Author:         cabalData["author"]
-            License:        cabalData["license"]
+        info := api.PkgInfo{
+            Name:           result["item"][8:],
+            Description:    strings.ReplaceAll(result["docs"], "\n", ""),
+            Version:        cabalData["version"],
+            HomepageURL:    result["url"] ,
+            SourceCodeURL:  cabalData["homepage"], 
+            // homepage tends to be the github page 
+            BugTrackerURL:  cabalData["bug-reports"],
+            Author:         cabalData["author"],
+            // sometimes this is author <email>
+            // other times it's just author and the email is in cabalData["maintainer"]
+            // possible todo ^^
+            License:        cabalData["license"],
             // will implement Dependencies later
         }
         finresults = append(finresults,info)
@@ -82,7 +93,7 @@ func searchFunction(query string, indiv bool = false) []api.PkgInfo {
     return finresults
 }
 
-InfoFunction = func(name string) {return searchFunction(name, indiv=true)[0]}
+
 
     
      

--- a/internal/backends/haskell/haskell.go
+++ b/internal/backends/haskell/haskell.go
@@ -3,8 +3,12 @@ package haskell
 import (
     "encoding/json"
     "net/http"
+    "net/url"
     "io/ioutil"
+    "regexp"
     "github.com/replit/upm/internal/api"
+    "github.com/replit/upm/internal/util"
+    "strings"
 )
 
 var HaskellBackend = api.LanguageBackend {
@@ -17,7 +21,9 @@ var HaskellBackend = api.LanguageBackend {
     // note : Stack actually uses two package directories:
     // ~/.stack/ for stackage packages and .stack-work for others
     Search:              searchFunction,
-    Info:                infoFunction
+    Info:                infoFunction,
+    
+
 
 }
 
@@ -36,27 +42,47 @@ type hoogleResult struct{
     docs string
 }
 
-func searchFunction(query string) []api.PkgInfo {
+func searchFunction(query string, indiv bool = false) []api.PkgInfo {
     // search stackage[hoogle] first
-    if res, err:= http.Get("https://hoogle.haskell.org/?mode=json&format=text&hoogle="+query+"%20is%3Apackage"), err!= nil {
-        panic(err)
+    res, err:= http.Get("https://hoogle.haskell.org/?mode=json&format=text&hoogle="+url.QueryEscape(query)+"%20is%3Apackage")
+    if err!= nil {
+        util.Die("hoogle response:"+ err.Error())
     }
     var results []hoogleResult
     data, _ := ioutil.Readall(res.Body)
     res.Body.Close()
     json.Unmarshal(data, &results)
     finresults = []api.PkgInfo{}
-    for result := range results{        
-        finresults = append(finresults, api.PkgInfo{
-            Name : result.item[8:]
-            // result.item is of the form "package packagename"
-            Description : result.docs
-            
-            
-
-
-
-    
+    if indiv {results = [results[0]]} // so we can skip implementing the search function again
+    for result := range results{
+        getCabal, err := http.Get(result.url + "/src/" + result.item[8:] + ".cabal")
+        if err!= nil {
+            util.Die("hackage [cabal file] response:" + err.Error())
+        }
+        cabal, _ := ioutil.ReadAll(getCabal.Body)
+        cabalRegexp := regexp.MustCompile(`\n(\S+): +(.?)\n`)
+        cabalDataSlice := cabalRegexp.FindAllSubmatch(cabal, -1)
+        cabalData := make(map[string]string)
+        for s := range cabalDataSlice{
+            cabalData[string(s[0])] = string(s[1])
+        }
+        var info api.PkgInfo{
+            Name:           result.item[8:]
+            Description:    strings.ReplaceAll(result.docs, "\n", " ")
+            Version:        cabalData["version"]
+            HomePageURL:    result.url 
+            SoourceCodeURL: cabalData["homepage"] //yes, homepage tends to be the github page 
+            BugTrackerURL:  cabalData["bug-reports"]
+            Author:         cabalData["author"]
+            License:        cabalData["license"]
+            // will implement Dependencies later
+        }
+        finresults = append(finresults,info)
+    }
+    return finresults
 }
+
+InfoFunction = func(name string) {return searchFunction(name, indiv=true)[0]}
+
     
      

--- a/internal/backends/haskell/haskell.go
+++ b/internal/backends/haskell/haskell.go
@@ -64,6 +64,9 @@ func searchFunction(query string, indiv bool) []api.PkgInfo {
     finresults := []api.PkgInfo{}
     if indiv {results = results[:1]} // so we can skip implementing the search function again
     for _,result := range results{
+        if result["item"] == ""{
+            continue
+        }
         getCabal, err := http.Get(result["url"] + "/src/" + result["item"][8:] + ".cabal")
         if err!= nil {
             util.Die("hackage [cabal file] response:" + err.Error())
@@ -92,6 +95,9 @@ func searchFunction(query string, indiv bool) []api.PkgInfo {
             // will implement Dependencies later
         }
         finresults = append(finresults,info)
+    }
+    if indiv && (len(finresults) == 0 || finresults[0].Name != query){
+        util.Die("cannot find package " + query)
     }
     return finresults
 }

--- a/internal/util/file.go
+++ b/internal/util/file.go
@@ -44,6 +44,7 @@ var IgnoredPaths = []string{
 	"tests",
 	"vendor",
 	"venv",
+    ".stack-work",
 }
 
 // AddIngoredPaths globally appends to the IngoredPaths list.


### PR DESCRIPTION
Currently a hacky implementation that relies (perhaps too heavily) on string manipulation and regular expressions. Guess not supported yet.

Won't work on the repl.it haskell image because the stack installation there is outdated. Should work with the latest version.