### PR TITLE
Add Ruby guessing (only for preinstalled Polygott gems)

### DIFF
--- a/internal/backends/ruby/ruby.go
+++ b/internal/backends/ruby/ruby.go
@@ -231,8 +231,17 @@ var RubyBackend = api.LanguageBackend{
 		}
 		return results
 	},
+	GuessRegexps: util.Regexps([]string{
+		`require\s*['"]([^'"]+)['"]`,
+	}),
 	Guess: func() (map[api.PkgName]bool, bool) {
-		util.NotImplemented()
-		panic("unreachable code")
+		guessedGems := util.GetCmdOutput([]string{
+			"ruby", "-e", util.GetResource("/ruby/guess-gems.rb"),
+		})
+		results := map[api.PkgName]bool{}
+		if err := json.Unmarshal(guessedGems, &results); err != nil {
+			util.Die("ruby: %s", err)
+		}
+		return results, true
 	},
 }

--- a/resources/ruby/guess-gems.rb
+++ b/resources/ruby/guess-gems.rb
@@ -1,0 +1,60 @@
+require 'parser/current'
+require 'json'
+
+# For now, we will only guess gems that come preinstalled in Polygott.
+# The mapping between what you require and the gem name is not always 1-to-1,
+# so we will need some sort of mapping like what we do with PyPi if we want
+# to do complete ruby gem guessing.
+$allowed_gems = [
+  "sinatra",
+  "stripe"
+]
+
+def guess_gems(code, guesses)
+  root = Parser::CurrentRuby.parse(code)
+  traverse_node(root, guesses)
+end
+
+def traverse_node(node, guesses)
+  if node.class != Parser::AST::Node
+    return
+  end
+  
+  # Looking for any s(:send, nil, :require, s(:str, "gem"))
+  if node.type == :send && node.children[1] == :require
+    req_node = node.children[2]
+    if req_node.class == Parser::AST::Node && req_node.type == :str
+      process_require(req_node.children.first, guesses)
+      return
+    end
+  end
+
+  node.children.each { |child|
+    traverse_node(child, guesses)
+  }
+end
+
+def process_require(req_str, guesses)
+  if req_str.empty?
+    return
+  end
+
+  # Skip absolute or relative requires
+  if req_str.start_with?('/') || req_str.start_with?('.')
+    return
+  end
+
+  # Handle requires like 'sinatra' or 'sinatra/content_for'
+  gem = req_str.split('/')[0]
+  if $allowed_gems.include?(gem)
+    guesses[gem] = true
+  end
+end
+
+guesses = {}
+
+Dir.glob("**/*.rb").reject {|f| f['./.bundle'] }.each { |file|
+  guess_gems(File.read(file), guesses)
+}
+
+puts guesses.to_json()

--- a/resources/ruby/guess-gems.rb
+++ b/resources/ruby/guess-gems.rb
@@ -5,10 +5,11 @@ require 'json'
 # The mapping between what you require and the gem name is not always 1-to-1,
 # so we will need some sort of mapping like what we do with PyPi if we want
 # to do complete ruby gem guessing.
-$allowed_gems = [
-  "sinatra",
-  "stripe"
-]
+$allowed_gems = { 
+  "sinatra" => "sinatra",
+  "sinatra/base" => "sinatra",
+  "stripe" => "stripe"
+}
 
 def guess_gems(code, guesses)
   root = Parser::CurrentRuby.parse(code)
@@ -44,9 +45,8 @@ def process_require(req_str, guesses)
     return
   end
 
-  # Handle requires like 'sinatra' or 'sinatra/content_for'
-  gem = req_str.split('/')[0]
-  if $allowed_gems.include?(gem)
+  gem = $allowed_gems[req_str]
+  if gem
     guesses[gem] = true
   end
 end

--- a/scripts/docker-install-languages.bash
+++ b/scripts/docker-install-languages.bash
@@ -54,5 +54,6 @@ ln -s "$HOME/.cask/bin/cask" /usr/local/bin/
 
 # https://github.com/docker-library/rails/issues/10#issuecomment-169957222
 bundle config --global silence_root_warning 1
+gem install parser
 
 rm /tmp/docker-install-languages.bash


### PR DESCRIPTION
This adds very basic Ruby gem guessing by walking the Ruby AST and looking for any `require 'somegem'` nodes and checking against a list of allowed guessable gems.

As noted in the guessing Ruby script, there isn't always a 1-to-1 mapping between what you `require` and the name of the gem to install. We want to move to using bundler to run Ruby repls without breaking compatibility with preexisting Ruby repls. When running via Bundler, globally installed gems are excluded from the environment. This means we need to, at least, guess the [preinstalled Polygott gems](https://github.com/replit/polygott/blob/7721bd5c9c8c50013801d1c581fb94a4508b2128/languages/ruby.toml#L16) (I excluded `rufo`, `rspec` and `solargraph` as those are used as binaries).

Before merging, we need to add the `parser` gem to Polygott.