### PR TITLE
Search python packages from local cache

### DIFF
--- a/internal/backends/python/gen_pypi_map/main.go
+++ b/internal/backends/python/gen_pypi_map/main.go
@@ -412,6 +412,22 @@ func pypiPackageToModules() map[string]string {
 
 	fmt.Fprintf(outgo, "}\n}\nreturn pypiPackageToModulesCached\n}")
 
+	fmt.Fprintf(outgo, `
+// pypiPackageToDownloads holds a map of every known python package to the number
+// of times it has been downloaded. This is used for ordering the python search
+// results.
+var pypiPackageToDownloadsCached = map[string]int{}
+
+func pypiPackageToDownloads() map[string]int {
+    if len(pypiPackageToDownloadsCached) == 0 {
+        pypiPackageToDownloadsCached = map[string]int{
+		`)
+
+	for _, pkg := range pkgs {
+		fmt.Fprintf(outgo, "\t\"%v\": %d,\n", pkg.Pkg, pkg.Downloads)
+	}
+	fmt.Fprintf(outgo, "}\n}\nreturn pypiPackageToDownloadsCached\n}")
+
 	err = outgo.Close()
 	if err != nil {
 		panic(err)

--- a/internal/backends/python/python.go
+++ b/internal/backends/python/python.go
@@ -8,7 +8,9 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
+	"sync"
 
 	"github.com/BurntSushi/toml"
 	"github.com/replit/upm/internal/api"
@@ -111,6 +113,60 @@ func normalizePackageName(name api.PkgName) api.PkgName {
 // "python3") to use when invoking Python. (This is used to implement
 // UPM_PYTHON2 and UPM_PYTHON3.)
 func pythonMakeBackend(name string, python string) api.LanguageBackend {
+	info_func := func(name api.PkgName) api.PkgInfo {
+		res, err := http.Get(fmt.Sprintf("https://pypi.org/pypi/%s/json", string(name)))
+
+		if err != nil {
+			util.Die("HTTP Request failed with error: %s", err)
+		}
+
+		defer res.Body.Close()
+
+		if res.StatusCode == 404 {
+			return api.PkgInfo{}
+		}
+
+		if res.StatusCode != 200 {
+			util.Die("Received status code: %d", res.StatusCode)
+		}
+
+		body, err := ioutil.ReadAll(res.Body)
+		if err != nil {
+			util.Die("Res body read failed with error: %s", err)
+		}
+
+		var output pypiEntryInfoResponse
+		if err := json.Unmarshal(body, &output); err != nil {
+			util.Die("PyPI response: %s", err)
+		}
+
+		info := api.PkgInfo{
+			Name:             output.Info.Name,
+			Description:      output.Info.Summary,
+			Version:          output.Info.Version,
+			HomepageURL:      output.Info.HomePage,
+			DocumentationURL: output.Info.DocsURL,
+			BugTrackerURL:    output.Info.BugTrackerURL,
+			Author: util.AuthorInfo{
+				Name:  output.Info.Author,
+				Email: output.Info.AuthorEmail,
+			}.String(),
+			License: output.Info.License,
+		}
+
+		deps := []string{}
+		for _, line := range output.Info.RequiresDist {
+			if strings.Contains(line, "extra ==") {
+				continue
+			}
+
+			deps = append(deps, strings.Fields(line)[0])
+		}
+		info.Dependencies = deps
+
+		return info
+	}
+
 	return api.LanguageBackend{
 		Name:             "python-" + name + "-poetry",
 		Specfile:         "pyproject.toml",
@@ -176,78 +232,39 @@ func pythonMakeBackend(name string, python string) api.LanguageBackend {
 			return filepath.Join(path, base+"-py"+version)
 		},
 		Search: func(query string) []api.PkgInfo {
-			outputB := util.GetCmdOutput([]string{
-				python, "-c",
-				util.GetResource("/python/pypi-search.py"),
-				query,
-			})
-			var outputJSON []pypiEntry
-			if err := json.Unmarshal(outputB, &outputJSON); err != nil {
-				util.Die("PyPI response: %s", err)
+			// Do a search on pypiPackageToModules
+			var packages []string
+			for p, _ := range pypiPackageToModules() {
+				if strings.Contains(p, query) {
+					packages = append(packages, p)
+				}
 			}
+
+			// Lookup the package info for each result
+			var barrier sync.WaitGroup
+			packageQueries := make(chan api.PkgInfo, len(packages))
+			for _, p := range packages {
+				barrier.Add(1)
+				go func(name api.PkgName) {
+					packageQueries <- info_func(name)
+					barrier.Done()
+				}(api.PkgName(p))
+			}
+			barrier.Wait()
+			close(packageQueries)
+
 			results := []api.PkgInfo{}
-			for i := range outputJSON {
-				results = append(results, api.PkgInfo{
-					Name:        outputJSON[i].Name,
-					Description: outputJSON[i].Summary,
-					Version:     outputJSON[i].Version,
-				})
+			for pkg := range packageQueries {
+				results = append(results, pkg)
 			}
+
+			sort.Slice(results, func(i, j int) bool {
+				return pypiPackageToDownloads()[results[i].Name] > pypiPackageToDownloads()[results[j].Name]
+			})
+
 			return results
 		},
-		Info: func(name api.PkgName) api.PkgInfo {
-			res, err := http.Get(fmt.Sprintf("https://pypi.org/pypi/%s/json", string(name)))
-
-			if err != nil {
-				util.Die("HTTP Request failed with error: %s", err)
-			}
-
-			defer res.Body.Close()
-
-			if res.StatusCode == 404 {
-				return api.PkgInfo{}
-			}
-
-			if res.StatusCode != 200 {
-				util.Die("Received status code: %d", res.StatusCode)
-			}
-
-			body, err := ioutil.ReadAll(res.Body)
-			if err != nil {
-				util.Die("Res body read failed with error: %s", err)
-			}
-
-			var output pypiEntryInfoResponse
-			if err := json.Unmarshal(body, &output); err != nil {
-				util.Die("PyPI response: %s", err)
-			}
-
-			info := api.PkgInfo{
-				Name:             output.Info.Name,
-				Description:      output.Info.Summary,
-				Version:          output.Info.Version,
-				HomepageURL:      output.Info.HomePage,
-				DocumentationURL: output.Info.DocsURL,
-				BugTrackerURL:    output.Info.BugTrackerURL,
-				Author: util.AuthorInfo{
-					Name:  output.Info.Author,
-					Email: output.Info.AuthorEmail,
-				}.String(),
-				License: output.Info.License,
-			}
-
-			deps := []string{}
-			for _, line := range output.Info.RequiresDist {
-				if strings.Contains(line, "extra ==") {
-					continue
-				}
-
-				deps = append(deps, strings.Fields(line)[0])
-			}
-			info.Dependencies = deps
-
-			return info
-		},
+		Info: info_func,
 		Add: func(pkgs map[api.PkgName]api.PkgSpec, projectName string) {
 			// Initalize the specfile if it doesnt exist
 			if !util.Exists("pyproject.toml") {


### PR DESCRIPTION
PyPi is deprecating the XMLRPC search interface. This searches for packages in the local UPM package mapping and displays results in order of downloads.