### PR TITLE
Fix nodejs backend not catching backtick only requires

### DIFF
--- a/internal/backends/nodejs/nodejs.go
+++ b/internal/backends/nodejs/nodejs.go
@@ -228,9 +228,9 @@ var nodejsGuessRegexps = util.Regexps([]string{
 	`(?m)from\s*['"]([^'"]+)['"]\s*;?\s*$`,
 	// import "module-name";
 	`(?m)import\s*['"]([^'"]+)['"]\s*;?\s*$`,
-	// const mod = import("module-name")
-	// const mod = require("module-name")
-	`(?m)(?:require|import)\s*\(\s*['"]([^'"{}]+)['"]\s*\)`,
+	// import("module-name") / import('module-name') / import(`module-name`)
+	// require("module-name") / require('module-name') / require(`module-name`)
+	`(?m)(?:require|import)\s*\(\s*['"` + "`" + `]([^'"{}]+)['"` + "`" + `]\s*\)`,
 })
 
 // nodejsGuess implements Guess for nodejs-yarn and nodejs-npm.

--- a/internal/backends/nodejs/nodejs_test.go
+++ b/internal/backends/nodejs/nodejs_test.go
@@ -1,0 +1,18 @@
+package nodejs
+
+import (
+	"testing"
+)
+
+func TestGuessRegexpsFindBacktickRequire(t *testing.T) {
+	contents := "require(`test`)"
+	found := false
+	for _, r := range NodejsNPMBackend.GuessRegexps {
+		if r.FindString(contents) != "" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("Guess regex search failed")
+	}
+}


### PR DESCRIPTION
This was a funky bug to catch! As soon as we included a require without backticks, the backtick require worked.