### PR TITLE
Ignore nodejs requires prefixed with 'node:'

### DIFF
--- a/internal/backends/nodejs/grab.go
+++ b/internal/backends/nodejs/grab.go
@@ -153,6 +153,13 @@ func guessBareImports() map[api.PkgName]bool {
 
 		for _, importPath := range result.ast.ImportPaths {
 			mod := importPath.Path.Text
+
+			// Since Node.js 16, you can prefix the import path with `node:` to denote that the
+			// module is a core module.
+			if strings.HasPrefix(mod, "node:") {
+				continue
+			}
+
 			isInternalMod := false
 			for _, internal := range internalModules {
 				if internal == mod {


### PR DESCRIPTION
Asana: https://app.asana.com/0/1199976029439378/1200303425700772

TL;DR: In Node.js 16 you can prefix core module requires with `node:`
Ex:
```
// old
const fs = require("fs");
// new
const fs = require("node:fs");
```

This breaks guessing because our internal module list only looks for `fs` and not `node:fs`.
Solution: Skip any modules with the `node:` prefix when guessing imports. 

## Test
Manually tested that guessing does not include `node:` prefixed modules.