### PR TITLE
Update circle CI ssh key fingerprint to new key

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
     steps:
       - add_ssh_keys:
           fingerprints:
-            - "6d:ae:08:71:61:cc:a1:b7:c8:87:f2:a3:84:ca:db:ad"
+            - "60:59:74:11:08:94:2e:c3:d2:5e:6b:03:17:1a:f8:8a"
       - run: apk add --no-cache --no-progress make git openssh
       - run:
           name: Keyscan Github (HACK) #https://discuss.circleci.com/t/known-hosts-in-circle-2-0/18544
@@ -20,7 +20,7 @@ jobs:
     steps:
       - add_ssh_keys:
           fingerprints:
-            - "6d:ae:08:71:61:cc:a1:b7:c8:87:f2:a3:84:ca:db:ad"
+            - "60:59:74:11:08:94:2e:c3:d2:5e:6b:03:17:1a:f8:8a"
       - run: apk add --no-cache --no-progress make git openssh
       - run:
           name: Keyscan Github (HACK) #https://discuss.circleci.com/t/known-hosts-in-circle-2-0/18544
@@ -41,7 +41,7 @@ jobs:
     steps:
       - add_ssh_keys:
           fingerprints:
-            - "6d:ae:08:71:61:cc:a1:b7:c8:87:f2:a3:84:ca:db:ad"
+            - "60:59:74:11:08:94:2e:c3:d2:5e:6b:03:17:1a:f8:8a"
       - run: apk add --no-cache --no-progress make git openssh
       - run:
           name: Keyscan Github (HACK) #https://discuss.circleci.com/t/known-hosts-in-circle-2-0/18544


### PR DESCRIPTION
The old one doesn't seem to work anymore. I made a new ssh keypair for upm's circleCI so that CI can push back to the repo.