### PR TITLE
Fixed the support for http/https imports in nodejs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /packaging/aur/src/
 *.gen.go
 /.vscode/
+/.idea/

--- a/Makefile
+++ b/Makefile
@@ -65,3 +65,8 @@ help: ## Show this message
 		sed 's/:[^#]*[#]# /|/'		| \
 		sed 's/%/LANG/'			| \
 		column -t -s'|' >&2
+
+.PHONY: test
+test: ## Run the tests
+	make upm
+	go test ./... -v

--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,11 @@ export GO111MODULE=on
 .PHONY: upm
 upm: cmd/upm/upm ## Build the UPM binary
 
-cmd/upm/upm: $(SOURCES) $(RESOURCES) $(GENERATED)
-	go run github.com/rakyll/statik -src resources -dest internal -f
+cmd/upm/upm: $(SOURCES) $(RESOURCES) $(GENERATED) statik
 	cd cmd/upm && go build -ldflags "-X 'github.com/replit/upm/internal/cli.version=$${VERSION:-development version}'"
+
+statik:
+	go run github.com/rakyll/statik -src resources -dest internal -f
 
 internal/backends/python/pypi_map.gen.go: internal/backends/python/pypi_packages.json
 	go generate ./internal/backends/python
@@ -67,6 +69,6 @@ help: ## Show this message
 		column -t -s'|' >&2
 
 .PHONY: test
-test: ## Run the tests
+test: statik ## Run the tests
 	make upm
 	go test ./... -v

--- a/Makefile
+++ b/Makefile
@@ -70,5 +70,4 @@ help: ## Show this message
 
 .PHONY: test
 test: statik ## Run the tests
-	make upm
 	go test ./... -v

--- a/internal/backends/nodejs/grab.go
+++ b/internal/backends/nodejs/grab.go
@@ -186,6 +186,11 @@ func guessBareImports() map[api.PkgName]bool {
 				continue
 			}
 
+			// Skip external files, don't import from http or https
+			if strings.HasPrefix(mod, "http:") || strings.HasPrefix(mod, "https:") {
+				continue
+			}
+
 			// Skip script loaders
 			if strings.Contains(mod, "!") {
 				continue

--- a/internal/backends/nodejs/nodejs_test.go
+++ b/internal/backends/nodejs/nodejs_test.go
@@ -1,0 +1,112 @@
+package nodejs
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/replit/upm/internal/api"
+)
+
+func TestNodejsYarnBackend_Guess(t *testing.T) {
+	tcs := []struct {
+		scenario    string
+		backend     api.LanguageBackend
+		fileContent string
+		expected    map[api.PkgName]bool
+	}{
+		{
+			scenario: "Returns the imports when given a JavaScript file with normal imports",
+			backend:  NodejsNPMBackend,
+			fileContent: `
+			import React from 'react';
+
+			export const App = () => null;
+		`,
+			expected: map[api.PkgName]bool{
+				"react": true,
+			},
+		},
+		{
+			scenario: "Ignore internal imports",
+			backend:  NodejsNPMBackend,
+			fileContent: `
+			const http = require('http');
+		`,
+			expected: map[api.PkgName]bool{},
+		},
+		{
+			scenario: "Ignore local file imports",
+			backend:  NodejsNPMBackend,
+			fileContent: `
+			import React from 'react';
+			import SomeComponent from './SomeComponent';
+
+			export const App = () => React.createElement(SomeComponent, {});
+		`,
+			expected: map[api.PkgName]bool{
+				"react": true,
+			},
+		},
+		{
+			scenario: "Ignore https file imports",
+			backend:  NodejsNPMBackend,
+			fileContent: `
+			import React from "https://cdn.skypack.dev/react";
+			import SomeComponent from './SomeComponent';
+
+			export const App = () => React.createElement(SomeComponent, {});
+		`,
+			expected: map[api.PkgName]bool{},
+		},
+		{
+			scenario: "Will process packages in namespace",
+			backend:  NodejsNPMBackend,
+			fileContent: `
+			import React from 'react';
+			import { Button } from '@material-ui/core';
+			
+			export const App = () => React.createElement(Button, { color: "primary" }, "Hello, World!");
+		`,
+			expected: map[api.PkgName]bool{
+				"react":             true,
+				"@material-ui/core": true,
+			},
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.scenario, func(t *testing.T) {
+			dir, err := ioutil.TempDir(".", "temp")
+			if err != nil {
+				t.Error(err)
+			}
+			defer os.RemoveAll(dir)
+
+			file, err := ioutil.TempFile(dir, "*.js")
+			if err != nil {
+				t.Error(err)
+			}
+
+			_, err = file.WriteString(tc.fileContent)
+			if err != nil {
+				t.Error(err)
+			}
+
+			result, ok := tc.backend.Guess()
+			if !ok {
+				t.Errorf("Guess return a non true value")
+			}
+
+			if len(tc.expected) != len(result) {
+				t.Errorf("Expected length of result to match length of expected")
+			}
+
+			for key := range tc.expected {
+				if _, ok := result[key]; !ok {
+					t.Errorf("Key %s not found in result map", key)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
We would parse http/https imports as NPM import through UPM, which would cause NPM to trigger errors as it tries to import packages using the URL path. Nodejs is on its way to support URL import paths and the browser already does it (Which is used by CDNs and tools like skypack), so this change should allow support for both future version of node and imports for the browser.

This is a relatively small change, so I took the opportunity to add a test suite for this backend and a make target to run the tests on demand.