### PR TITLE
Add nix build files

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -8,9 +8,7 @@ in
 let
     src = ./.;
 
-    gitSrc = builtins.filterSource
-                   (path: type: true)
-                   ./.;
+    gitSrc = pkgs.copyPathToStore ./.;
     revision = runCommand "get-rev" {
         nativeBuildInputs = [ git ];
         dummy = builtins.currentTime;

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,22 @@
+{ lib, buildGoModule, fetchFromGitHub, statik }:
+
+buildGoModule rec {
+    name = "upm";
+    version = "908674b";
+
+    src = fetchFromGitHub{
+        owner = "replit";
+        repo = "upm";
+        rev = "${version}";
+        sha256 = "0y50q2fxz1q1xbxirjka70y247x70xxz8kj1h8dmgrzd793k3y6s";
+    };
+
+    vendorSha256 = "1fjk4wjcqdkwhwgvx907pxd9ga8lfa36xrkh64ld5b8d0cv62mzv";
+
+    preBuild = ''
+        ${statik}/bin/statik -src resources -dest internal -f
+        go generate ./internal/backends/python
+    '';
+
+    doCheck = false;
+}

--- a/default.nix
+++ b/default.nix
@@ -6,19 +6,20 @@ let
     runCommand = pkgs.runCommand;
 in
 let
-    gitSrc = builtins.filterSource
-               (path: type: true)
-               ./.;
-in
-buildGoModule rec {
-    pname = "upm";
     src = ./.;
 
+    gitSrc = builtins.filterSource
+                   (path: type: true)
+                   ./.;
     revision = runCommand "get-rev" {
         nativeBuildInputs = [ git ];
         dummy = builtins.currentTime;
     } "GIT_DIR=${gitSrc}/.git git rev-parse --short HEAD | tr -d '\n' > $out";
+in buildGoModule {
+    pname = "upm";
     version = builtins.readFile revision;
+
+    inherit src;
 
     vendorSha256 = "1fjk4wjcqdkwhwgvx907pxd9ga8lfa36xrkh64ld5b8d0cv62mzv";
 

--- a/default.nix
+++ b/default.nix
@@ -1,14 +1,16 @@
 { pkgs ? import <nixpkgs>{} } :
 let
-    buildGoModule = pkgs.buildGoModule;
-    statik = pkgs.statik;
-    git = pkgs.git;
-    runCommand = pkgs.runCommand;
+    inherit(pkgs)
+        buildGoModule
+        statik
+        git
+        runCommand;
 in
 let
     src = pkgs.copyPathToStore ./.;
     revision = runCommand "get-rev" {
         nativeBuildInputs = [ git ];
+        # impure, do every time, see https://github.com/NixOS/nixpkgs/blob/master/pkgs/build-support/fetchgitlocal/default.nix#L9
         dummy = builtins.currentTime;
     } "GIT_DIR=${src}/.git git rev-parse --short HEAD | tr -d '\n' > $out";
 in buildGoModule {

--- a/default.nix
+++ b/default.nix
@@ -6,13 +6,11 @@ let
     runCommand = pkgs.runCommand;
 in
 let
-    src = ./.;
-
-    gitSrc = pkgs.copyPathToStore ./.;
+    src = pkgs.copyPathToStore ./.;
     revision = runCommand "get-rev" {
         nativeBuildInputs = [ git ];
         dummy = builtins.currentTime;
-    } "GIT_DIR=${gitSrc}/.git git rev-parse --short HEAD | tr -d '\n' > $out";
+    } "GIT_DIR=${src}/.git git rev-parse --short HEAD | tr -d '\n' > $out";
 in buildGoModule {
     pname = "upm";
     version = builtins.readFile revision;

--- a/default.nix
+++ b/default.nix
@@ -1,15 +1,24 @@
-{ lib, buildGoModule, fetchFromGitHub, statik }:
-
+{ pkgs ? import <nixpkgs>{} } :
+let
+    buildGoModule = pkgs.buildGoModule;
+    statik = pkgs.statik;
+    git = pkgs.git;
+    runCommand = pkgs.runCommand;
+in
+let
+    gitSrc = builtins.filterSource
+               (path: type: true)
+               ./.;
+in
 buildGoModule rec {
-    name = "upm";
-    version = "908674b";
+    pname = "upm";
+    src = ./.;
 
-    src = fetchFromGitHub{
-        owner = "replit";
-        repo = "upm";
-        rev = "${version}";
-        sha256 = "0y50q2fxz1q1xbxirjka70y247x70xxz8kj1h8dmgrzd793k3y6s";
-    };
+    revision = runCommand "get-rev" {
+        nativeBuildInputs = [ git ];
+        dummy = builtins.currentTime;
+    } "GIT_DIR=${gitSrc}/.git git rev-parse --short HEAD | tr -d '\n' > $out";
+    version = builtins.readFile revision;
 
     vendorSha256 = "1fjk4wjcqdkwhwgvx907pxd9ga8lfa36xrkh64ld5b8d0cv62mzv";
 


### PR DESCRIPTION
This PR adds the files from https://github.com/replit/nixpkgs-replit/tree/main/pkgs/upm directly to upm to reduce the number of repositories we have to update to push changes.