### PR TITLE
Add support for fetching the custom version through the API

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -4,17 +4,28 @@ let
         buildGoModule
         statik
         git
+        python3
         runCommand;
 in
 let
+    packageName = "upm";
+
     src = pkgs.copyPathToStore ./.;
+    versionFile = builtins.fetchurl https://api.github.com/repos/replit/upm/commits/master;
     revision = runCommand "get-rev" {
-        nativeBuildInputs = [ git ];
+        nativeBuildInputs = [ git python3 ];
         # impure, do every time, see https://github.com/NixOS/nixpkgs/blob/master/pkgs/build-support/fetchgitlocal/default.nix#L9
         dummy = builtins.currentTime;
-    } "GIT_DIR=${src}/.git git rev-parse --short HEAD | tr -d '\n' > $out";
+    } ''
+        if [ -d ${src}/.git ]; then
+            cd ${src}
+            git rev-parse --short HEAD | tr -d '\n' > $out
+        else
+            cat ${versionFile} | python3 -c "import sys, json; print(json.load(sys.stdin)['sha'][0:7])" | tr -d '\n' > $out
+        fi
+    '';
 in buildGoModule {
-    pname = "upm";
+    pname = packageName;
     version = builtins.readFile revision;
 
     inherit src;


### PR DESCRIPTION
When the dynamic version code was executed through niv, the .git folder would be missing. This is because niv downloads the archive from github using an URL without getting the .git folder, since it is never really pushed.

That's a big problem for us and this PR fixes that issue by adding an if and checking if said .git folder exists. If not, it will use the version information from the API and parse the short sha from there.