### PR TITLE
Fix nix build

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,15 +1,8 @@
 { pkgs ? import <nixpkgs>{}, versionArg ? "" } :
 let
-    inherit(pkgs)
-        buildGoModule
-        statik
-        git
-        runCommand;
-in
-let
     src = pkgs.copyPathToStore ./.;
-    revision = runCommand "get-rev" {
-        nativeBuildInputs = [ git python3 ];
+    revision = pkgs.runCommand "get-rev" {
+        nativeBuildInputs = with pkgs; [ git python3 ];
         # impure, do every time, see https://github.com/NixOS/nixpkgs/blob/master/pkgs/build-support/fetchgitlocal/default.nix#L9
         dummy = builtins.currentTime;
     } ''
@@ -20,7 +13,7 @@ let
             echo ${versionArg} | tr -d '\n' > $out
         fi
     '';
-in buildGoModule {
+in pkgs.buildGoModule {
     pname = "upm";
     version = builtins.readFile revision;
 
@@ -29,7 +22,7 @@ in buildGoModule {
     vendorSha256 = "1fjk4wjcqdkwhwgvx907pxd9ga8lfa36xrkh64ld5b8d0cv62mzv";
 
     preBuild = ''
-        ${statik}/bin/statik -src resources -dest internal -f
+        ${pkgs.statik}/bin/statik -src resources -dest internal -f
         go generate ./internal/backends/python
     '';
 

--- a/default.nix
+++ b/default.nix
@@ -1,18 +1,20 @@
 { pkgs ? import <nixpkgs>{}, versionArg ? "" } :
 let
+
     src = pkgs.copyPathToStore ./.;
+
     revision = pkgs.runCommand "get-rev" {
-        nativeBuildInputs = with pkgs; [ git python3 ];
+        nativeBuildInputs = with pkgs; [ git ];
         # impure, do every time, see https://github.com/NixOS/nixpkgs/blob/master/pkgs/build-support/fetchgitlocal/default.nix#L9
         dummy = builtins.currentTime;
     } ''
         if [ -d ${src}/.git ]; then
-            cd ${src}
-            git rev-parse --short HEAD | tr -d '\n' > $out
+            git --git-dir="${src}/.git" -C "${src}" rev-parse --short HEAD | tr -d '\n' > $out
         else
             echo ${versionArg} | tr -d '\n' > $out
         fi
     '';
+
 in pkgs.buildGoModule {
     pname = "upm";
     version = builtins.readFile revision;

--- a/result
+++ b/result
@@ -1,0 +1,1 @@
+/nix/store/rad9dm9x4j6l8vzpw7wal04jpdsj2fl7-upm-ac649e7


### PR DESCRIPTION
The nix build was failing because python3 wasn't defined. I made `pkgs` usage a bit more inline as well.