### PR TITLE
Implement Nix in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,12 @@ jobs:
       - checkout
       - setup_remote_docker
       - run: make light full
+  nix_build:
+    docker:
+      - image: docker.nix-community.org/nixpkgs/nix
+    steps:
+      - checkout
+      - run: nix-build
   build_test_and_deploy:
     docker:
       - image: docker:18.09

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,6 +96,12 @@ workflows:
               ignore: master
             tags:
               ignore: /.*/
+      - nix_build:
+          filters:
+            branches:
+              ignore: master
+            tags:
+              ignore: /.*/
       - build_test_and_deploy:
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,14 @@ jobs:
       - image: nixos/nix
     steps:
       - checkout
+      - restore_cache:
+          key: nix-store
       - run: nix-build
+      - save_cache:
+          key: nix-store
+          when: always
+          paths:
+            - /nix
   build_test_and_deploy:
     docker:
       - image: docker:18.09

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
       - run: make light full
   nix_build:
     docker:
-      - image: docker.nix-community.org/nixpkgs/nix
+      - image: nixos/nix
     steps:
       - checkout
       - run: nix-build

--- a/result
+++ b/result
@@ -1,1 +1,0 @@
-/nix/store/rad9dm9x4j6l8vzpw7wal04jpdsj2fl7-upm-ac649e7


### PR DESCRIPTION
This flow currently only builds the nix package using the official Nix docker images. It will run all phases, but will not test the package once built. It does run the checks though.