### PR TITLE
Use Nix flake

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,7 @@ jobs:
       - checkout
       - restore_cache:
           key: nix-store
+      - run: nix-env -iA nixpkgs.git
       - run: nix-build
       - save_cache:
           key: nix-store

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,8 @@ jobs:
       - restore_cache:
           key: nix-store
       - run: nix-env -iA nixpkgs.git
+      - run: git diff
+      - run: git status
       - run: nix-build
       - save_cache:
           key: nix-store

--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,6 @@
 *.gen.go
 /.vscode/
 /.idea/
+
+# nix build creates a "result" symlink to the nix store output
 result

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 *.gen.go
 /.vscode/
 /.idea/
+result

--- a/default.nix
+++ b/default.nix
@@ -1,7 +1,8 @@
-{ buildGoModule, statik } :
+{ buildGoModule, statik, rev } :
 
 buildGoModule {
-    name = "upm";
+    pname = "upm";
+    version = rev;
 
     src = ./.;
 

--- a/default.nix
+++ b/default.nix
@@ -1,17 +1,7 @@
-{ buildGoModule, statik, rev } :
-
-buildGoModule {
-    pname = "upm";
-    version = rev;
-
-    src = ./.;
-
-    vendorSha256 = "1fjk4wjcqdkwhwgvx907pxd9ga8lfa36xrkh64ld5b8d0cv62mzv";
-
-    preBuild = ''
-        ${statik}/bin/statik -src resources -dest internal -f
-        go generate ./internal/backends/python
-    '';
-
-    doCheck = false;
-}
+(import (
+  fetchTarball {
+    url = "https://github.com/edolstra/flake-compat/archive/99f1c2157fba4bfe6211a321fd0ee43199025dbf.tar.gz";
+    sha256 = "0x2jn3vrawwv9xp15674wjz9pixwjyj3j771izayl962zziivbx2"; }
+) {
+  src =  ./.;
+}).defaultNix

--- a/default.nix
+++ b/default.nix
@@ -1,30 +1,14 @@
-{ pkgs ? import <nixpkgs>{}, versionArg ? "" } :
-let
+{ buildGoModule, statik } :
 
-    src = pkgs.copyPathToStore ./.;
+buildGoModule {
+    name = "upm";
 
-    revision = pkgs.runCommand "get-rev" {
-        nativeBuildInputs = with pkgs; [ git ];
-        # impure, do every time, see https://github.com/NixOS/nixpkgs/blob/master/pkgs/build-support/fetchgitlocal/default.nix#L9
-        dummy = builtins.currentTime;
-    } ''
-        if [ -d ${src}/.git ]; then
-            git --git-dir="${src}/.git" -C "${src}" rev-parse --short HEAD | tr -d '\n' > $out
-        else
-            echo ${versionArg} | tr -d '\n' > $out
-        fi
-    '';
-
-in pkgs.buildGoModule {
-    pname = "upm";
-    version = builtins.readFile revision;
-
-    inherit src;
+    src = ./.;
 
     vendorSha256 = "1fjk4wjcqdkwhwgvx907pxd9ga8lfa36xrkh64ld5b8d0cv62mzv";
 
     preBuild = ''
-        ${pkgs.statik}/bin/statik -src resources -dest internal -f
+        ${statik}/bin/statik -src resources -dest internal -f
         go generate ./internal/backends/python
     '';
 

--- a/default.nix
+++ b/default.nix
@@ -1,3 +1,4 @@
+# flake-compat makes Nix flakes compatible with the old Nix cli commands, like nix-build and nix-shell.
 (import (
   fetchTarball {
     url = "https://github.com/edolstra/flake-compat/archive/99f1c2157fba4bfe6211a321fd0ee43199025dbf.tar.gz";

--- a/flake.lock
+++ b/flake.lock
@@ -17,15 +17,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1625502818,
-        "narHash": "sha256-TI7v5cmG1zJCIya7vPWDqXsdOhfSJeaQIQr89MfalMY=",
+        "lastModified": 1625512941,
+        "narHash": "sha256-P2POZzfG+Hp8ktIWwkOs/OMB8jSsQvIPQaLO0swpgZo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "249f41469923093ceff18c2c4c34291c54ac2c25",
+        "rev": "3e0ce8c5d478d06b37a4faa7a4cc8642c6bb97de",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,42 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1623875721,
+        "narHash": "sha256-A8BU7bjS5GirpAUv4QA+QnJ4CceLHkcXdRp4xITDB0s=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "f7e004a55b120c02ecb6219596820fcd32ca8772",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1625502818,
+        "narHash": "sha256-TI7v5cmG1zJCIya7vPWDqXsdOhfSJeaQIQr89MfalMY=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "249f41469923093ceff18c2c4c34291c54ac2c25",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -11,7 +11,7 @@
       (system:
         let
           pkgs = nixpkgs.legacyPackages.${system};
-          upm = pkgs.callPackage ./default.nix {
+          upm = pkgs.callPackage ./upm.nix {
             rev = if self ? rev then "0.1.0-${builtins.substring 0 7 self.rev}" else "0.1.0-dirty";
           };
         in

--- a/flake.nix
+++ b/flake.nix
@@ -12,7 +12,7 @@
         let
           pkgs = nixpkgs.legacyPackages.${system};
           upm = pkgs.callPackage ./upm.nix {
-            rev = if self ? rev then "0.1.0-${builtins.substring 0 7 self.rev}" else "0.1.0-dirty";
+            rev = if self ? rev then "0.0.0-${builtins.substring 0 7 self.rev}" else "0.0.0-dirty";
           };
         in
         {

--- a/flake.nix
+++ b/flake.nix
@@ -9,10 +9,17 @@
   outputs = { self, nixpkgs, flake-utils }:
     flake-utils.lib.eachDefaultSystem
       (system:
-        let pkgs = nixpkgs.legacyPackages.${system}; upm = pkgs.callPackage ./default.nix {}; in
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+          upm = pkgs.callPackage ./default.nix {
+            rev = if self ? rev then "0.1.0-${builtins.substring 0 7 self.rev}" else "0.1.0-dirty";
+          };
+        in
         {
-          packages = [ upm ];
           defaultPackage = upm;
+          packages = {
+            inherit upm;
+          };
         }
       );
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,18 @@
+{
+  description = "Universal Package Manager";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem
+      (system:
+        let pkgs = nixpkgs.legacyPackages.${system}; upm = pkgs.callPackage ./default.nix {}; in
+        {
+          packages = [ upm ];
+          defaultPackage = upm;
+        }
+      );
+}

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "Universal Package Manager";
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs";
+    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
     flake-utils.url = "github:numtide/flake-utils";
   };
 

--- a/result
+++ b/result
@@ -1,1 +1,0 @@
-/nix/store/63pln8qafch9hhjfvp4lm6hha5db7vd3-upm-0.1.0-50e80cc

--- a/result
+++ b/result
@@ -1,0 +1,1 @@
+/nix/store/63pln8qafch9hhjfvp4lm6hha5db7vd3-upm-0.1.0-50e80cc

--- a/upm.nix
+++ b/upm.nix
@@ -1,0 +1,17 @@
+{ buildGoModule, statik, rev } :
+
+buildGoModule {
+    pname = "upm";
+    version = rev;
+
+    src = ./.;
+
+    vendorSha256 = "1fjk4wjcqdkwhwgvx907pxd9ga8lfa36xrkh64ld5b8d0cv62mzv";
+
+    preBuild = ''
+        ${statik}/bin/statik -src resources -dest internal -f
+        go generate ./internal/backends/python
+    '';
+
+    doCheck = false;
+}

--- a/upm.nix
+++ b/upm.nix
@@ -8,6 +8,10 @@ buildGoModule {
 
     vendorSha256 = "1fjk4wjcqdkwhwgvx907pxd9ga8lfa36xrkh64ld5b8d0cv62mzv";
 
+    buildFlagsArray = [
+      "-ldflags=-X github.com/replit/upm/internal/cli.version=${rev}"
+    ];
+
     preBuild = ''
         ${statik}/bin/statik -src resources -dest internal -f
         go generate ./internal/backends/python


### PR DESCRIPTION
This adds a `flake.nix` file which locks nixpkgs and uses the fancy new Nix 2.0 commands. It also has built-in support for getting the git revision for us. The default.nix file provides a flake-compat shim which allows upm to be built using the old Nix commands like `nix-build`.