### PR TITLE
Add --no-update to poetry lock

### DIFF
--- a/internal/backends/python/python.go
+++ b/internal/backends/python/python.go
@@ -303,7 +303,7 @@ func pythonMakeBackend(name string, python string) api.LanguageBackend {
 			util.RunCmd(cmd)
 		},
 		Lock: func() {
-			util.RunCmd([]string{python, "-m", "poetry", "lock"})
+			util.RunCmd([]string{python, "-m", "poetry", "lock", "--no-update"})
 		},
 		Install: func() {
 			// Unfortunately, this doesn't necessarily uninstall


### PR DESCRIPTION
The default behavior of `poetry lock` is to update the lockfile to the latest compatible version of a package:
> By default, this will lock all dependencies to the latest available compatible versions. To only refresh the lock file, use the `--no-update` option. This command is also available as a pre-commit hook. See pre-commit hooks for more information.
([ref](https://python-poetry.org/docs/cli/#lock))

Repls that are created from templates will therefore also update packages on their first run, which is both slow and also potentially breaks the template's functionality.

This PR adds the `--no-update` flag so the default `poetry lock` that runs every time the packager runs does not result in unintended updates.