### PR TITLE
Disable esparse's TS option to avoid removal of unused imports

### DIFF
--- a/internal/backends/nodejs/grab.go
+++ b/internal/backends/nodejs/grab.go
@@ -1,15 +1,16 @@
 package nodejs
 
 import (
+	"io/ioutil"
+	"log"
+	"path/filepath"
+	"strings"
+
 	"github.com/amasad/esparse/ast"
 	"github.com/amasad/esparse/logging"
 	"github.com/amasad/esparse/parser"
 	"github.com/replit/upm/internal/api"
 	"github.com/replit/upm/internal/util"
-	"io/ioutil"
-	"log"
-	"path/filepath"
-	"strings"
 )
 
 var internalModules = []string{
@@ -70,17 +71,17 @@ type parseResult struct {
 
 func parseFile(source logging.Source, results chan parseResult) {
 	parseOptions := parser.ParseOptions{
-		IsBundling: true,
+		IsBundling:   true,
+		MangleSyntax: false,
 	}
 
 	// Always parse jsx
 	parseOptions.JSX.Parse = true
+	// TS parsing strips unused imports, that becomes
+	// inconsistent with the regex-based import searching used to
+	// generate the guess hash, so we disable it
+	parseOptions.TS.Parse = false
 
-	ext := getExt(source.AbsolutePath)
-
-	if ext == ".ts" || ext == ".tsx" {
-		parseOptions.TS.Parse = true
-	}
 	logo, _ := logging.NewDeferLog()
 
 	ast, ok := parser.Parse(logo, source, parseOptions)

--- a/internal/backends/nodejs/nodejs.go
+++ b/internal/backends/nodejs/nodejs.go
@@ -219,13 +219,19 @@ func nodejsListSpecfile() map[api.PkgName]api.PkgSpec {
 	return pkgs
 }
 
-// Don't use guess regexps to calculate hash because:
-//  1. github.com/amasad/esparse which we use to get the module list strips modules that
-//     were imported but the import not used, which causes situation where if the user
-//     guesses with unused imports, it results in the guess hash representing the import
-//     being present while the real guess does not, causing inconsistencies.
-//  2. esparse is fast anyway, not noticably slower than searching via regexp
-var nodejsGuessRegexps = []*regexp.Regexp{}
+// nodejsGuessRegexps is the value of GuessRegexps for nodejs-yarn and
+// nodejs-npm.
+var nodejsGuessRegexps = util.Regexps([]string{
+	// import defaultExport from "module-name";
+	// import * as name from "module-name";
+	// import { export } from "module-name";
+	`(?m)from\s*['"]([^'"]+)['"]\s*;?\s*$`,
+	// import "module-name";
+	`(?m)import\s*['"]([^'"]+)['"]\s*;?\s*$`,
+	// const mod = import("module-name")
+	// const mod = require("module-name")
+	`(?m)(?:require|import)\s*\(\s*['"]([^'"{}]+)['"]\s*\)`,
+})
 
 // nodejsGuess implements Guess for nodejs-yarn and nodejs-npm.
 func nodejsGuess() (map[api.PkgName]bool, bool) {

--- a/internal/backends/nodejs/nodejs_test.go
+++ b/internal/backends/nodejs/nodejs_test.go
@@ -8,13 +8,15 @@ import (
 	"github.com/replit/upm/internal/api"
 )
 
+type TestCase struct {
+	scenario    string
+	backend     api.LanguageBackend
+	fileContent string
+	expected    map[api.PkgName]bool
+}
+
 func TestNodejsYarnBackend_Guess(t *testing.T) {
-	tcs := []struct {
-		scenario    string
-		backend     api.LanguageBackend
-		fileContent string
-		expected    map[api.PkgName]bool
-	}{
+	tcs := []TestCase{
 		{
 			scenario: "Returns the imports when given a JavaScript file with normal imports",
 			backend:  NodejsNPMBackend,
@@ -28,12 +30,34 @@ func TestNodejsYarnBackend_Guess(t *testing.T) {
 			},
 		},
 		{
+			scenario: "Returns normal requires",
+			backend:  NodejsNPMBackend,
+			fileContent: `
+			const request = require('request');
+		`,
+			expected: map[api.PkgName]bool{
+				"request": true,
+			},
+		},
+		{
 			scenario: "Ignore internal imports",
 			backend:  NodejsNPMBackend,
 			fileContent: `
 			const http = require('http');
 		`,
 			expected: map[api.PkgName]bool{},
+		},
+		{
+			scenario: "Returns both requires and imports in mixed file",
+			backend:  NodejsNPMBackend,
+			fileContent: `
+			const request = require('request');
+			import yargs from 'yargs';
+		`,
+			expected: map[api.PkgName]bool{
+				"request": true,
+				"yargs":   true,
+			},
 		},
 		{
 			scenario: "Ignore local file imports",
@@ -73,41 +97,100 @@ func TestNodejsYarnBackend_Guess(t *testing.T) {
 				"@material-ui/core": true,
 			},
 		},
+		{
+			scenario: "Conditional require",
+			backend:  NodejsNPMBackend,
+			fileContent: `
+			if (process.env.NODE_ENV === "production") { 
+				require("node-fetch");
+			}
+		`,
+			expected: map[api.PkgName]bool{
+				"node-fetch": true,
+			},
+		},
+		{
+			scenario: "types then conditional require",
+			backend:  NodejsNPMBackend,
+			fileContent: `
+			type Field<T> = { field: string; };
+
+			if (process.env.NODE_ENV === "production") { 
+				require("node-fetch");
+			}
+		`,
+			expected: map[api.PkgName]bool{},
+		},
+		{
+			scenario: "dynamic import",
+			backend:  NodejsNPMBackend,
+			fileContent: `
+
+			if (process.env.NODE_ENV === "production") { 
+				import("node-fetch");
+			}
+		`,
+			expected: map[api.PkgName]bool{
+				"node-fetch": true,
+			},
+		},
+		{
+			scenario: "typings then dynamic import",
+			backend:  NodejsNPMBackend,
+			fileContent: `
+			type Field<T> = { field: string; };
+
+			if (process.env.NODE_ENV === "production") { 
+				import("node-fetch");
+			}
+		`,
+			expected: map[api.PkgName]bool{},
+		},
 	}
 
 	for _, tc := range tcs {
 		tc := tc
-		t.Run(tc.scenario, func(t *testing.T) {
-			dir, err := ioutil.TempDir(".", "temp")
-			if err != nil {
-				t.Error(err)
-			}
-			defer os.RemoveAll(dir)
+		t.Run(tc.scenario+"in js", func(t *testing.T) {
+			verify(t, tc, "js")
 
-			file, err := ioutil.TempFile(dir, "*.js")
-			if err != nil {
-				t.Error(err)
-			}
-
-			_, err = file.WriteString(tc.fileContent)
-			if err != nil {
-				t.Error(err)
-			}
-
-			result, ok := tc.backend.Guess()
-			if !ok {
-				t.Errorf("Guess return a non true value")
-			}
-
-			if len(tc.expected) != len(result) {
-				t.Errorf("Expected length of result to match length of expected")
-			}
-
-			for key := range tc.expected {
-				if _, ok := result[key]; !ok {
-					t.Errorf("Key %s not found in result map", key)
-				}
-			}
 		})
+
+		t.Run(tc.scenario+" in ts", func(t *testing.T) {
+			verify(t, tc, "ts")
+
+		})
+	}
+}
+
+func verify(t *testing.T, tc TestCase, extension string) {
+	dir, err := ioutil.TempDir(".", "temp")
+	if err != nil {
+		t.Error(err)
+	}
+	defer os.RemoveAll(dir)
+
+	file, err := ioutil.TempFile(dir, "*."+extension)
+	if err != nil {
+		t.Error(err)
+	}
+
+	_, err = file.WriteString(tc.fileContent)
+	if err != nil {
+		t.Error(err)
+	}
+
+	result, ok := tc.backend.Guess()
+	if !ok {
+		t.Errorf("Guess return a non true value")
+	}
+
+	if len(tc.expected) != len(result) {
+		t.Errorf("Expected length of result to match length of expected")
+	}
+
+	for key := range tc.expected {
+		if _, ok := result[key]; !ok {
+			t.Errorf("Key %s not found in result map", key)
+		}
 	}
 }


### PR DESCRIPTION
# Why?

We have a bug where if you first run a file with an un-used import, say:

```ts
import isOdd from 'is-odd';
```

Then you update the code to use the import and run it again:

```ts
import isOdd from 'is-odd';
console.log(isOdd(3));
```

You get a module 'is-odd' is not found error because:

1. upm failed to auto install the module during the 1st run because the unused import was striped by [esparse (fork of esbuild)](https://github.com/amasad/esparse) before the guesser could include the module
2. in the second run, the guesser used the cached result from the first run because the hash key is based on import statements grabbed using regexp searches instead of eparse: https://github.com/replit/upm/blob/master/internal/store/util.go#L32

More context:
https://app.asana.com/0/1201647179266797/1202932490289607/f

# What Changed?

1. disabled the TS.Parse option of esparse
2. disabled the MangleSyntax option of esparse
3. the above 2 together disable the removal of unused imports in the parsing process: https://github.com/amasad/esparse/blob/master/parser/parser.go#L7614. Basically we put the parser into JS parse mode that can cope with TS but just ignores the semantics of TS. This is ok for what we want: just the list of import statements. This also has the nice effect that the user can write the statement: `import something from 'something'`, run it, and get the library installed, which I think is more intuitive.