### PR TITLE
Make development on Replit first-class

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,2 +1,10 @@
-language = "go"
-run = "make"
+run = "make && echo \"UPM is built, can be found here: ./cmd/upm/upm\""
+
+[nix]
+channel = "stable-21_11" # Only channel with go 1.17
+
+[languages.go]
+pattern = "**/*.go"
+
+[languages.go.languageServer]
+start = "gopls"

--- a/README.md
+++ b/README.md
@@ -442,10 +442,28 @@ All of these dependencies are already installed in the
       make clean     Remove build artifacts
       make help      Show this message
 
-To build UPM, run `make upm` (or just `make`). This requires an
-installation of [Go](https://golang.org/). Then add the directory
-`./cmd/upm` to your `$PATH` so that you can run the binary. To remove
-build artifacts, run `make clean`.
+To build UPM, run `make upm` (or just `make`), the built
+binary can be found in `./cmd/upm/upm`. To remove build
+artifacts, run `make clean`.
+
+### Using Replit (simplest)
+
+You can develop UPM on Replit. Simply click on [this](https://replit.com/new/github/replit/upm)
+link and the repo will start cloning into a Repl.
+
+Once you're in your new Repl, you can hit run
+to build a new binary (or `make` in shell). You can create
+a test folder and use the binary and test your changes.
+For example say you made a change to the `nodejs-npm` language
+and want to test it, you would hit run and do the following:
+
+    $ mkdir testnpm
+    $ cd testnpm
+    $ npm init -y
+    $ ../cmd/upm/upm add left-pad -l nodejs-npm
+
+
+### Using Docker
 
 You can use [Docker](https://www.docker.com/) to avoid needing to
 install the package managers that UPM drives. To do this, run `make

--- a/replit.nix
+++ b/replit.nix
@@ -1,0 +1,26 @@
+{ pkgs }: {
+    deps = [
+        pkgs.wget
+        pkgs.gnumake
+        pkgs.go_1_17
+        pkgs.gopls
+        pkgs.gcc
+        pkgs.curl
+        pkgs.git
+        pkgs.jq
+        pkgs.maven
+        pkgs.emacs-nox
+        pkgs.cask
+        pkgs.nodejs-16_x
+        pkgs.yarn
+        pkgs.python39Full
+        pkgs.python39Packages.pip
+        pkgs.python39Packages.poetry
+        pkgs.R
+        pkgs.ruby
+        pkgs.sqlite
+        pkgs.less
+      # does not include python 2
+    ];
+}
+


### PR DESCRIPTION
This PR makes it possible to develop by adding required dependencies to `replit.nix` (though I may have missed something) and configuring LSP.

The only thing I did not port is python 2 stuff, but that's dead at this point.