### PR TITLE
(nodejs): Catch internal submodules (ex. dns/promises)

### DIFF
--- a/internal/backends/nodejs/grab.go
+++ b/internal/backends/nodejs/grab.go
@@ -1,7 +1,6 @@
 package nodejs
 
 import (
-	"fmt"
 	"io/ioutil"
 	"log"
 	"path/filepath"
@@ -162,17 +161,6 @@ func guessBareImports() map[api.PkgName]bool {
 				continue
 			}
 
-			isInternalMod := false
-			for _, internal := range internalModules {
-				if internal == mod || strings.HasPrefix(mod, fmt.Sprintf("%s/", internal)) {
-					isInternalMod = true
-					break
-				}
-			}
-			if isInternalMod {
-				continue
-			}
-
 			// Skip empty imports
 			if mod == "" {
 				continue
@@ -198,7 +186,7 @@ func guessBareImports() map[api.PkgName]bool {
 				continue
 			}
 
-			// Handle scoped modules
+			// Handle scoped modules or internal modules
 			if mod[0] == '@' {
 				parts := strings.Split(mod, "/")
 				if len(parts) < 2 {
@@ -208,6 +196,17 @@ func guessBareImports() map[api.PkgName]bool {
 			} else {
 				parts := strings.Split(mod, "/")
 				mod = parts[0]
+
+				isInternalMod := false
+				for _, internal := range internalModules {
+					if internal == mod {
+						isInternalMod = true
+						break
+					}
+				}
+				if isInternalMod {
+					continue
+				}
 			}
 
 			pkgs[api.PkgName(mod)] = true

--- a/internal/backends/nodejs/grab.go
+++ b/internal/backends/nodejs/grab.go
@@ -1,6 +1,7 @@
 package nodejs
 
 import (
+	"fmt"
 	"io/ioutil"
 	"log"
 	"path/filepath"
@@ -163,7 +164,7 @@ func guessBareImports() map[api.PkgName]bool {
 
 			isInternalMod := false
 			for _, internal := range internalModules {
-				if internal == mod {
+				if internal == mod || strings.HasPrefix(mod, fmt.Sprintf("%s/", internal)) {
 					isInternalMod = true
 					break
 				}

--- a/internal/backends/nodejs/nodejs_test.go
+++ b/internal/backends/nodejs/nodejs_test.go
@@ -48,6 +48,14 @@ func TestNodejsYarnBackend_Guess(t *testing.T) {
 			expected: map[api.PkgName]bool{},
 		},
 		{
+			scenario: "Ignore internal submodules imports",
+			backend:  NodejsNPMBackend,
+			fileContent: `
+			const dns = require('dns/promises');
+		`,
+			expected: map[api.PkgName]bool{},
+		},
+		{
 			scenario: "Returns both requires and imports in mixed file",
 			backend:  NodejsNPMBackend,
 			fileContent: `


### PR DESCRIPTION
Right now, UPM doesn't catch internal submodules correctly.



For example:
```js
require('dns/promises')
```

will cause to UPM to try and install the ``dns`` package even though it's an internal module.


@masad-frost 