### PR TITLE
Add support for .mjs and .cjs for package guessing

### DIFF
--- a/internal/backends/nodejs/nodejs.go
+++ b/internal/backends/nodejs/nodejs.go
@@ -78,7 +78,7 @@ type packageLockJSON struct {
 }
 
 // nodejsPatterns is the FilenamePatterns value for NodejsBackend.
-var nodejsPatterns = []string{"*.js", "*.ts", "*.jsx", "*.tsx"}
+var nodejsPatterns = []string{"*.js", "*.ts", "*.jsx", "*.tsx", "*.mjs", "*.cjs"}
 
 // nodejsSearch implements Search for nodejs-yarn and nodejs-npm.
 func nodejsSearch(query string) []api.PkgInfo {


### PR DESCRIPTION
Module-type file extension are growing in popularity due to the funky ecosystem