### PR TITLE
java: fix maven url

### DIFF
--- a/internal/backends/java/msch.go
+++ b/internal/backends/java/msch.go
@@ -33,7 +33,7 @@ import (
 )
 
 const (
-	mavenURL string = "http://search.maven.org/solrsearch/select?q="
+	mavenURL string = "https://search.maven.org/solrsearch/select?q="
 )
 
 type SearchDoc struct {


### PR DESCRIPTION
https is needed now

tested that this fixes `upm search -l java junit`