### PR TITLE
Fix maven API requests using http instead of https

### DIFF
--- a/internal/backends/java/msch.go
+++ b/internal/backends/java/msch.go
@@ -33,7 +33,7 @@ import (
 )
 
 const (
-	mavenURL string = "http://search.maven.org/solrsearch/select?q="
+	mavenURL string = "https://search.maven.org/solrsearch/select?q="
 )
 
 type SearchDoc struct {


### PR DESCRIPTION
Looks like we use http instead of https when talking to maven and that suddenly stopped working.

Tests in msch_test.go should have us covered.