### PR TITLE
rlang: use https for search

### DIFF
--- a/internal/backends/rlang/search.go
+++ b/internal/backends/rlang/search.go
@@ -73,7 +73,7 @@ type CranResponse struct {
 
 func searchPackages(name string, size int) CranResponse {
 	// TODO: figure out how to deal with other mirrors
-	searchURL := "http://search.r-pkg.org/package/_search?q=" + url.QueryEscape(name) + "&size=" + strconv.Itoa(size)
+	searchURL := "https://search.r-pkg.org/package/_search?q=" + url.QueryEscape(name) + "&size=" + strconv.Itoa(size)
 
 	if req, err := http.Get(searchURL); err == nil {
 		var res CranResponse


### PR DESCRIPTION
Why
===

* We recently had trouble with Maven becoming inaccessible via http
* Let's preemptively change this last one.

What Changed
============

* Changed URL to https

Test plan
=========
* `nix run .# -- search -l rlang limit`