### PR TITLE
Override for faiss

### DIFF
--- a/internal/backends/python/pypi_map.override.go
+++ b/internal/backends/python/pypi_map.override.go
@@ -8,4 +8,5 @@ var moduleToPypiPackageOverride = map[string]string{
 	"nvd3":         "python-nvd3",         // not popular enough 6th in popularity
 	"requirements": "requirements-parser", // popular rlbot depends on it, but doesn't supply requires_dist
 	"base62":       "pybase62",            // it was overridden by base-62 which wins due to name match but is less popular by far
+	"faiss":        "faiss-cpu",
 }


### PR DESCRIPTION
# Why?

Package guesser doesn't give a good result for [faiss](https://github.com/facebookresearch/faiss). The [faiss package](https://pypi.org/project/faiss/) on pypi is broken, the user should install `faiss_cpu` or `faiss_gpu`. We'll default it to the cpu version.

## Changes

Added override for faiss guess result.

## Test

1. `make upm`
2. make a test directory with a `main.py` that contains `import faiss`. Do `upm guess` and see that it gives `faiss-cpu`.