### PR TITLE
Call poetry as an executable instead of as a module of python

### DIFF
--- a/internal/backends/python/python.go
+++ b/internal/backends/python/python.go
@@ -191,7 +191,7 @@ func pythonMakeBackend(name string, python string) api.LanguageBackend {
 			// so complicated??)
 
 			outputB := util.GetCmdOutput([]string{
-				python, "-m", "poetry",
+				"poetry",
 				"config", "settings.virtualenvs.path",
 			})
 			var path string
@@ -260,7 +260,7 @@ func pythonMakeBackend(name string, python string) api.LanguageBackend {
 		Add: func(pkgs map[api.PkgName]api.PkgSpec, projectName string) {
 			// Initalize the specfile if it doesnt exist
 			if !util.Exists("pyproject.toml") {
-				cmd := []string{python, "-m", "poetry", "init", "--no-interaction"}
+				cmd := []string{"poetry", "init", "--no-interaction"}
 
 				if projectName != "" {
 					cmd = append(cmd, "--name", projectName)
@@ -269,7 +269,7 @@ func pythonMakeBackend(name string, python string) api.LanguageBackend {
 				util.RunCmd(cmd)
 			}
 
-			cmd := []string{python, "-m", "poetry", "add"}
+			cmd := []string{"poetry", "add"}
 			for name, spec := range pkgs {
 				name := string(name)
 				spec := string(spec)
@@ -288,14 +288,14 @@ func pythonMakeBackend(name string, python string) api.LanguageBackend {
 			util.RunCmd(cmd)
 		},
 		Remove: func(pkgs map[api.PkgName]bool) {
-			cmd := []string{python, "-m", "poetry", "remove"}
+			cmd := []string{"poetry", "remove"}
 			for name := range pkgs {
 				cmd = append(cmd, string(name))
 			}
 			util.RunCmd(cmd)
 		},
 		Lock: func() {
-			util.RunCmd([]string{python, "-m", "poetry", "lock", "--no-update"})
+			util.RunCmd([]string{"poetry", "lock", "--no-update"})
 		},
 		Install: func() {
 			// Unfortunately, this doesn't necessarily uninstall
@@ -303,7 +303,7 @@ func pythonMakeBackend(name string, python string) api.LanguageBackend {
 			// which happens for example if 'poetry remove' is
 			// interrupted. See
 			// <https://github.com/sdispater/poetry/issues/648>.
-			util.RunCmd([]string{python, "-m", "poetry", "install"})
+			util.RunCmd([]string{"poetry", "install"})
 		},
 		ListSpecfile: func() map[api.PkgName]api.PkgSpec {
 			pkgs, err := listSpecfile()


### PR DESCRIPTION
# Why?

Needed for the Python Nix module to work. With the poetry setup where it is installed in its own virtual environment, we can no longer put poetry on the library path of python and therefore we cannot call poetry as a module. Instead we need to call it as an executable.

## Changes

calling poetry as a standalone executable

## Testing

1. compile upm via `make upm; make install`
2. upload upm to a repl
3. hack the `PATH` to make it show up first
4. activate the python module `modules = ["python"]`
5. setup a `PYTHONUSERBASE` variable as `$HOME/$REPL_SLUG/.pythonlibs`
6. `poetry init` in the repl directory if this was a blank repl
7. try using the packager to install a python package like pyyaml

Play in this repl which already has the above set up: https://replit.com/join/vvfytgyghu-tobyho