### PR TITLE
Add PNPM support

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ machine-parseable specfile and lockfile listing.
 | python-python3-poetry | yes  | yes   | yes   |
 | python-python2-poetry | yes  | yes   | yes   |
 | nodejs-yarn           | yes  | yes   | yes   |
+| nodejs-pnpm           | yes  | yes   | yes   |
 | nodejs-npm            | yes  | yes   | yes   |
 | ruby-bundler          | yes  | yes   |       |
 | elisp-cask            | yes  | yes   | yes   |
@@ -415,6 +416,10 @@ installed, as follows:
 * `nodejs-yarn`
   * [Node.js](https://nodejs.org/en/)
   * [Yarn](https://yarnpkg.com/en/) for Yarn backend
+  * [NPM](https://www.npmjs.com/get-npm) for NPM backend
+* `nodejs-pnpm`
+  * [Node.js](https://nodejs.org/en/)
+  * [PNPM](https://pnpm.io/) for PNPM backend
   * [NPM](https://www.npmjs.com/get-npm) for NPM backend
 * `ruby-bundler`
   * [Ruby](https://www.ruby-lang.org/en/)

--- a/internal/backends/backends.go
+++ b/internal/backends/backends.go
@@ -29,6 +29,7 @@ var languageBackends = []api.LanguageBackend{
 	python.Python2Backend,
 	nodejs.BunBackend,
 	nodejs.NodejsNPMBackend,
+    nodejs.NodejsPNPMBackend,
 	nodejs.NodejsYarnBackend,
 	ruby.RubyBackend,
 	elisp.ElispBackend,

--- a/replit.nix
+++ b/replit.nix
@@ -13,6 +13,7 @@
         pkgs.cask
         pkgs.nodejs-16_x
         pkgs.yarn
+        pkgs.nodePackages.pnpm
         pkgs.python39Full
         pkgs.python39Packages.pip
         pkgs.python39Packages.poetry

--- a/scripts/docker-install-languages.bash
+++ b/scripts/docker-install-languages.bash
@@ -45,6 +45,7 @@ yarn
 export DEBIAN_FRONTEND=noninteractive
 apt-get update
 apt-get install -y $packages
+curl -fsSL https://get.pnpm.io/install.sh | sh - # Install via script given that PNPM is not on APT
 rm -rf /var/lib/apt/lists/*
 
 pip2 --disable-pip-version-check install poetry


### PR DESCRIPTION
This PR adds support for the NodeJS package manager [PNPM](https://pnpm.io).

I have tested this by running the command specified in the README and there were no issues.

One thing to note is running `pnpm init` will force the user to interact with no flag to accept all the defaults. Because of this, I have used `npm init -y` for creating the `package.json` file.