### PR TITLE
[python] add graphics module override

### DIFF
--- a/internal/backends/python/pypi_map.override.go
+++ b/internal/backends/python/pypi_map.override.go
@@ -9,4 +9,5 @@ var moduleToPypiPackageOverride = map[string]string{
 	"requirements": "requirements-parser", // popular rlbot depends on it, but doesn't supply requires_dist
 	"base62":       "pybase62",            // it was overridden by base-62 which wins due to name match but is less popular by far
 	"faiss":        "faiss-cpu",
+	"graphics":     "graphics.py",         // this package is popular, but the module doesn't match the package name https://anh.cs.luc.edu/python/hands-on/3.1/handsonHtml/graphics.html#a-graphics-introduction
 }


### PR DESCRIPTION
Why
===
* This is a popular graphics library in python, and Ghostwriter suggested code that used it, but the package guesser didn't know to install the package.

What changed
===
* Add an override so the package guesser knows to guess "graphics.py" for "graphics"

Test plan
===
1. Deploy UPM
2. Add "import graphics" to a Python Repl main.py
3. Click run
4. Do not see an error