### PR TITLE
fix require import detection

### DIFF
--- a/internal/backends/nodejs/grab.go
+++ b/internal/backends/nodejs/grab.go
@@ -72,7 +72,7 @@ func parseFile(contents []byte, results chan parseResult) {
 (
 	(call_expression
 		function: (identifier) @function
-		arguments: (arguments ((_) @other-imports)? ((_) @import) .))
+		arguments: (arguments ((_) @other-imports)? ((string) @import) .))
 	(#eq? @function "require"))
 `
 


### PR DESCRIPTION
# why
1. When there isn't a string input to a require statement we are guessing an invalid package
2. It doesn't install any of the packages if one fails

# what changed
changed the tree-sitter query for javascript to only accept `require` imports if they're a single string

<img width="756" alt="image" src="https://github.com/replit/upm/assets/23486351/3bc20d93-1b01-4833-b7ce-8c389111361b">
