### PR TITLE
Allow submodules in an import statement to be considered by guesser; …

### DIFF
--- a/internal/backends/python/pypi_map.override.go
+++ b/internal/backends/python/pypi_map.override.go
@@ -9,5 +9,6 @@ var moduleToPypiPackageOverride = map[string]string{
 	"requirements": "requirements-parser", // popular rlbot depends on it, but doesn't supply requires_dist
 	"base62":       "pybase62",            // it was overridden by base-62 which wins due to name match but is less popular by far
 	"faiss":        "faiss-cpu",
-	"graphics":     "graphics.py",         // this package is popular, but the module doesn't match the package name https://anh.cs.luc.edu/python/hands-on/3.1/handsonHtml/graphics.html#a-graphics-introduction
+	"graphics":     "graphics.py", // this package is popular, but the module doesn't match the package name https://anh.cs.luc.edu/python/hands-on/3.1/handsonHtml/graphics.html#a-graphics-introduction
+	"replit.ai":    "replit-ai",   // Replit's AI package
 }

--- a/internal/backends/python/pypi_map.override.go
+++ b/internal/backends/python/pypi_map.override.go
@@ -11,5 +11,4 @@ var moduleToPypiPackageOverride = map[string]string{
 	"faiss":        "faiss-cpu",
 	"graphics":     "graphics.py", // this package is popular, but the module doesn't match the package name https://anh.cs.luc.edu/python/hands-on/3.1/handsonHtml/graphics.html#a-graphics-introduction
 	"replit.ai":    "replit-ai",   // Replit's AI package
-	"google.cloud": "google-cloud", // GCP SDK
 }

--- a/internal/backends/python/pypi_map.override.go
+++ b/internal/backends/python/pypi_map.override.go
@@ -11,4 +11,5 @@ var moduleToPypiPackageOverride = map[string]string{
 	"faiss":        "faiss-cpu",
 	"graphics":     "graphics.py", // this package is popular, but the module doesn't match the package name https://anh.cs.luc.edu/python/hands-on/3.1/handsonHtml/graphics.html#a-graphics-introduction
 	"replit.ai":    "replit-ai",   // Replit's AI package
+	"google.cloud": "google-cloud", // GCP SDK
 }

--- a/internal/backends/python/python.go
+++ b/internal/backends/python/python.go
@@ -380,7 +380,8 @@ func guess(python string) (map[api.PkgName]bool, bool) {
 
 	pkgs := map[api.PkgName]bool{}
 
-	for modname, pragmas := range output.Imports {
+	for fullModname, pragmas := range output.Imports {
+		modname := getTopLevelModuleName(fullModname)
 		// provided by an existing package or perhaps by the system
 		if availMods[modname] {
 			continue
@@ -395,7 +396,10 @@ func guess(python string) (map[api.PkgName]bool, bool) {
 			// Otherwise, try and look it up in Pypi
 			var pkg string
 			var ok bool
-			pkg, ok = moduleToPypiPackageOverride[modname]
+			pkg, ok = moduleToPypiPackageOverride[fullModname]
+			if !ok {
+				pkg, ok = moduleToPypiPackageOverride[modname]
+			}
 			if !ok {
 				pkg, ok = pypiMap.ModuleToPackage(modname)
 			}
@@ -407,6 +411,10 @@ func guess(python string) (map[api.PkgName]bool, bool) {
 	}
 
 	return pkgs, output.Success
+}
+
+func getTopLevelModuleName(fullModname string) string {
+	return strings.Split(fullModname, ".")[0]
 }
 
 // getPython2 returns either "python2" or the value of the UPM_PYTHON2

--- a/resources/python/pipreqs.py
+++ b/resources/python/pipreqs.py
@@ -87,14 +87,7 @@ def get_all_imports(
                 had_errors = True
                 continue
 
-    # Clean up imports
-    for name in raw_imports.keys():
-        # Cleanup: We only want to first part of the import.
-        # Ex: from django.conf --> django.conf. But we only want django
-        # as an import.
-        cleaned_name, _, _ = name.partition('.')
-        imports[cleaned_name] = raw_imports[name]
-
+    imports = raw_imports
     missing_modules = imports.keys() - (set(candidates) & imports.keys())
     return {k: imports[k] for k in missing_modules}, had_errors
 


### PR DESCRIPTION
…add replit-ai as override

# Why?

Want to support package guessing `replit.ai` module mapping to `replit-ai` on pypi. UPM doesn't currently consider submodules in the import.

## Changes

1. Changed pipreqs.py to not strip submodules
2. Added code to strip submodules in the Python guessing code
3. Allow using the full module path (with submodules) in looking up the module resolution overrides.