### PR TITLE
continually test parents of submodules

### DIFF
--- a/internal/backends/python/python.go
+++ b/internal/backends/python/python.go
@@ -414,7 +414,7 @@ func guess(python string) (map[api.PkgName]bool, bool) {
 				}
 
 				// loop with everything except the deepest submodule
-				modNameParts = modNameParts[:len(modNameParts)-2]
+				modNameParts = modNameParts[:len(modNameParts)-1]
 			}
 
 			if ok {

--- a/internal/backends/python/python.go
+++ b/internal/backends/python/python.go
@@ -7,7 +7,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strings"
 
 	"github.com/BurntSushi/toml"
@@ -398,26 +397,26 @@ func guess(python string) (map[api.PkgName]bool, bool) {
 			var pkg string
 			var ok bool
 
-      modNameParts := strings.Split(fullModname, ".")
-      for len(modNameParts) > 0 {
-        testModName := strings.Join(modNameParts, ".")
+			modNameParts := strings.Split(fullModname, ".")
+			for len(modNameParts) > 0 {
+				testModName := strings.Join(modNameParts, ".")
 
-        // test overrides
-        pkg, ok = moduleToPypiPackageOverride[testModName]
-        if ok {
-          break
-        }
+				// test overrides
+				pkg, ok = moduleToPypiPackageOverride[testModName]
+				if ok {
+					break
+				}
 
-        // test pypi
-        pkg, ok = pypiMap.ModuleToPackage(testModName)
-        if ok {
-          break
-        }
+				// test pypi
+				pkg, ok = pypiMap.ModuleToPackage(testModName)
+				if ok {
+					break
+				}
 
-        // loop with everything except the deepest submodule
-        modNameParts = modNameParts[:len(modNameParts) - 2]
-      }
-      
+				// loop with everything except the deepest submodule
+				modNameParts = modNameParts[:len(modNameParts)-2]
+			}
+
 			if ok {
 				name := api.PkgName(pkg)
 				pkgs[normalizePackageName(name)] = true


### PR DESCRIPTION
## Why

guess doesn't work when importing eg `replit.ai.google.language_models`

## What changed

instead of testing only `replit.ai.google.language_models` or `replit`, now test `replit.ai.google.language_models` then `replit.ai.google` then `replit.ai` then `replit`

## Testing

run `upm guess` against a file containing:
```py
import replit.ai.google.language_models
```

and `replit-ai` is installed

then run `upm guess` against a file containing:
```py
import replit.ai.google
```

and `replit-ai` is installed

then run `upm guess` against a file containing:
```py
import replit.ai
```

and `replit-ai` is installed

then run `upm guess` against a file containing:
```py
import replit
```

and `replit` is installed