### PR TITLE
dont install if theres no specfile, dont care about lockfile

### DIFF
--- a/internal/cli/cmds.go
+++ b/internal/cli/cmds.go
@@ -191,7 +191,7 @@ func maybeInstall(b api.LanguageBackend, forceInstall bool) {
 	}
 
 	if b.QuirksIsReproducible() {
-		if !util.Exists(b.Lockfile) || !util.Exists(b.GetPackageDir()) || forceInstall || store.HasLockfileChanged(b) {
+		if forceInstall || !util.Exists(b.Lockfile) || !util.Exists(b.GetPackageDir()) || store.HasLockfileChanged(b) {
 			b.Install()
 		}
 	} else {

--- a/internal/cli/cmds.go
+++ b/internal/cli/cmds.go
@@ -186,17 +186,15 @@ func maybeLock(b api.LanguageBackend, forceLock bool) bool {
 // maybeInstall either runs install or not, depending on the backend,
 // store, and command-line options.
 func maybeInstall(b api.LanguageBackend, forceInstall bool) {
+	if !util.Exists(b.Specfile) {
+		return
+	}
+
 	if b.QuirksIsReproducible() {
-		if !util.Exists(b.Lockfile) {
-			return
-		}
 		if forceInstall || store.HasLockfileChanged(b) {
 			b.Install()
 		}
 	} else {
-		if !util.Exists(b.Specfile) {
-			return
-		}
 		if forceInstall || store.HasSpecfileChanged(b) {
 			b.Install()
 		}

--- a/internal/cli/cmds.go
+++ b/internal/cli/cmds.go
@@ -191,7 +191,7 @@ func maybeInstall(b api.LanguageBackend, forceInstall bool) {
 	}
 
 	if b.QuirksIsReproducible() {
-		if forceInstall || store.HasLockfileChanged(b) {
+		if !util.Exists(b.GetPackageDir()) || !util.Exists(b.Lockfile) || forceInstall || store.HasLockfileChanged(b) {
 			b.Install()
 		}
 	} else {

--- a/internal/cli/cmds.go
+++ b/internal/cli/cmds.go
@@ -191,7 +191,7 @@ func maybeInstall(b api.LanguageBackend, forceInstall bool) {
 	}
 
 	if b.QuirksIsReproducible() {
-		if !util.Exists(b.GetPackageDir()) || !util.Exists(b.Lockfile) || forceInstall || store.HasLockfileChanged(b) {
+		if !util.Exists(b.Lockfile) || !util.Exists(b.GetPackageDir()) || forceInstall || store.HasLockfileChanged(b) {
 			b.Install()
 		}
 	} else {


### PR DESCRIPTION
## why

if in a project with only `package.json`, and you run `upm -l bun install -f`, nothing happens. should probably install in this situation...

## what changed

- `maybeInstall` always exits if there's no specfile
- if a package manager is reproducible, and the package-dir doesn't exist, or the lockfile doesn't exist, then installs dependencies