### PR TITLE
remove statik

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,7 @@ install: cmd/upm/upm
 internal/backends/python/pypi_map.sqlite: internal/backends/python/download_stats.json
 	cd internal/backends/python; go run ./gen_pypi_map -bq download_stats.json -pkg python -out pypi_map.sqlite -cache cache -cmd gen
 
-.PHONY: generated
-generated: internal/statik/statik.go $(GENERATED)
+generated: $(GENERATED)
 
 cmd/upm/upm: $(SOURCES) $(RESOURCES) generated
 	cd cmd/upm && go build -ldflags $(LD_FLAGS)
@@ -23,12 +22,8 @@ cmd/upm/upm: $(SOURCES) $(RESOURCES) generated
 build-release: $(SOURCES) $(RESOURCES) generated
 	goreleaser build
 
-internal/statik/statik.go: $(shell find resources -type f)
-	go run github.com/rakyll/statik -src resources -dest internal -f
-
 clean-gen:
 	rm -f $(GENERATED)
-	rm -rf internal/statik
 
 .PHONY: dev
 dev: ## Run a shell with UPM source code and all package managers inside Docker
@@ -83,5 +78,5 @@ help: ## Show this message
 		column -t -s'|' >&2
 
 .PHONY: test
-test: internal/statik/statik.go ## Run the tests
+test:
 	go test ./... -v

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/mattn/go-sqlite3 v1.14.17
 	github.com/natefinch/atomic v0.0.0-20150920032501-a62ce929ffcc
-	github.com/rakyll/statik v0.1.6
 	github.com/smacker/go-tree-sitter v0.0.0-20230501083651-a7d92773b3aa
 	github.com/spf13/cobra v0.0.5
 	github.com/stretchr/testify v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -82,8 +82,6 @@ github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/9
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
-github.com/rakyll/statik v0.1.6 h1:uICcfUXpgqtw2VopbIncslhAmE5hwc4g20TEyEENBNs=
-github.com/rakyll/statik v0.1.6/go.mod h1:OEi9wJV/fMUAGx1eNjq75DKDsJVuEv1U0oYdX6GX8Zs=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 github.com/smacker/go-tree-sitter v0.0.0-20230501083651-a7d92773b3aa h1:exZ0FwfhblsYbgfqYH+W/3sFye821WD02NjBmc+ENhE=
 github.com/smacker/go-tree-sitter v0.0.0-20230501083651-a7d92773b3aa/go.mod h1:q99oHDsbP0xRwmn7Vmob8gbSMNyvJ83OauXPSuHQuKE=

--- a/internal/util/file.go
+++ b/internal/util/file.go
@@ -170,9 +170,7 @@ func TempDir() string {
 
 // GetResourceBytes is like GetResource but returns a []byte.
 func GetResourceBytes(url string) []byte {
-	if strings.HasPrefix(url, "/") {
-		url = url[1:]
-	}
+	url = strings.TrimPrefix(url, "/")
 
 	res, err := resources.Resources.ReadFile(url)
 	if err != nil {

--- a/internal/util/file.go
+++ b/internal/util/file.go
@@ -8,9 +8,10 @@ import (
 	"path"
 	"path/filepath"
 	"regexp"
+	"strings"
 
-	"github.com/replit/upm/resources"
 	"github.com/natefinch/atomic"
+	"github.com/replit/upm/resources"
 )
 
 // IgnoredPaths is a slice of file patterns that are totally ignored
@@ -169,6 +170,10 @@ func TempDir() string {
 
 // GetResourceBytes is like GetResource but returns a []byte.
 func GetResourceBytes(url string) []byte {
+	if strings.HasPrefix(url, "/") {
+		url = url[1:]
+	}
+
 	res, err := resources.Resources.ReadFile(url)
 	if err != nil {
 		panic(err)

--- a/internal/util/file.go
+++ b/internal/util/file.go
@@ -9,9 +9,8 @@ import (
 	"path/filepath"
 	"regexp"
 
+	"github.com/replit/upm/resources"
 	"github.com/natefinch/atomic"
-	sfs "github.com/rakyll/statik/fs"
-	_ "github.com/replit/upm/internal/statik"
 )
 
 // IgnoredPaths is a slice of file patterns that are totally ignored
@@ -168,26 +167,17 @@ func TempDir() string {
 	}
 }
 
-// hfs is the statik http.FileSystem, once initialized.
-var statikFS *http.FileSystem
-
 // GetResourceBytes is like GetResource but returns a []byte.
 func GetResourceBytes(url string) []byte {
-	if statikFS == nil {
-		if hfs, err := sfs.New(); err != nil {
-			panic(err)
-		} else {
-			statikFS = &hfs
-		}
-	}
-	if bytes, err := sfs.ReadFile(*statikFS, url); err != nil {
+	res, err := resources.Resources.ReadFile(url)
+	if err != nil {
 		panic(err)
-	} else {
-		return bytes
 	}
+
+	return res
 }
 
-// GetResource returns a statik resource as a string. Resources are
+// GetResource returns a static resource as a string. Resources are
 // inside the resources/ directory of the UPM source repository. url
 // is HTTP-style, e.g. "/nodejs/bare-imports.js". The return value is
 // the file contents. If the resource does not exist, GetResource
@@ -196,7 +186,7 @@ func GetResource(url string) string {
 	return string(GetResourceBytes(url))
 }
 
-// WriteResource writes a statik resource to a temporary directory.
+// WriteResource writes a static resource to a temporary directory.
 // url is as in GetResource. The file is put inside tempdir, with the
 // same basename as from url. If the resource does not exist,
 // WriteResource panics. If the write fails, it terminates the

--- a/nix/upm/default.nix
+++ b/nix/upm/default.nix
@@ -1,6 +1,5 @@
 {
   buildGoModule,
-  statik,
   rev,
   makeWrapper,
 }:
@@ -17,7 +16,6 @@ buildGoModule {
   ];
 
   preBuild = ''
-    ${statik}/bin/statik -src resources -dest internal -f
     go generate ./internal/backends/python
   '';
 

--- a/nix/upm/default.nix
+++ b/nix/upm/default.nix
@@ -9,7 +9,7 @@ buildGoModule {
 
   src = ../../.;
 
-  vendorSha256 = "sha256-RXpw5JGKUPBkjSO7ZNnXO6XtOwF+y3Gd9bXPP2bBDj4=";
+  vendorHash = "sha256-2F2/BcHUEpbYxmAW1SsIBbn6U2VWinWjdxMvsbzfKsc=";
 
   ldflags = [
     "-X github.com/replit/upm/internal/cli.version=${rev}"

--- a/resources/resources.go
+++ b/resources/resources.go
@@ -1,0 +1,9 @@
+package resources
+
+import (
+	"embed"
+)
+
+//go:embed *
+var Resources embed.FS
+


### PR DESCRIPTION
# why

statik sucks. keeps breaking things and there's an ***embed***ded tool for this in go itself (see what i did there?)

# what changed

- changed use of statik to `go:embed`
- as a result, created `github.com/replit/upm/resources` package
  - NB it's public facing