### PR TITLE
add install-replit-nix-system-dependencies subcommand

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,25 @@
 {
   "nodes": {
+    "nix-editor": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1697051330,
+        "narHash": "sha256-WUdCSm7+ckKv3IvTOmP8TOyqIXKXCRNE2RCrGl5J1hU=",
+        "owner": "replit",
+        "repo": "nix-editor",
+        "rev": "2ecfe2bc906c07fba727ca00a784b88248eefef7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "replit",
+        "repo": "nix-editor",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1694062546,
@@ -18,6 +38,7 @@
     },
     "root": {
       "inputs": {
+        "nix-editor": "nix-editor",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -1,10 +1,16 @@
 {
   description = "Universal Package Manager";
   inputs.nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+  # nix-editor is a dev dependency in this project. At Replit, we use
+  # nix-editor directly too, so nix-editor is already in the
+  # environment.
+  inputs.nix-editor.url = "github:replit/nix-editor";
+  inputs.nix-editor.inputs.nixpkgs.follows = "nixpkgs";
 
   outputs = {
     self,
     nixpkgs,
+    nix-editor,
   }: let
     systems = [
       "aarch64-darwin"
@@ -20,7 +26,7 @@
   in {
     packages = eachSystem (system:
       import ./nix {
-        inherit self nixpkgs rev system;
+        inherit self nixpkgs rev system nix-editor;
       });
     devShells = eachSystem (system: {
       default = self.packages.${system}.devShell;

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -308,6 +308,10 @@ type LanguageBackend struct {
 	//
 	// This field is mandatory.
 	Guess func() (map[PkgName]bool, bool)
+
+	// Installs system dependencies into replit.nix for supported
+	// languages.
+	InstallReplitNixSystemDependencies func([]PkgName)
 }
 
 // Setup panics if the given language backend does not specify all of

--- a/internal/backends/dart/dart.go
+++ b/internal/backends/dart/dart.go
@@ -13,6 +13,7 @@ import (
 	"runtime"
 
 	"github.com/replit/upm/internal/api"
+	"github.com/replit/upm/internal/nix"
 	"github.com/replit/upm/internal/util"
 	"gopkg.in/yaml.v2"
 )
@@ -302,8 +303,9 @@ var DartPubBackend = api.LanguageBackend{
 	Install: func() {
 		util.RunCmd([]string{"pub", "get"})
 	},
-	ListSpecfile: dartListPubspecYaml,
-	ListLockfile: dartListPubspecLock,
-	GuessRegexps: nil,
-	Guess:        dartGuess,
+	ListSpecfile:                       dartListPubspecYaml,
+	ListLockfile:                       dartListPubspecLock,
+	GuessRegexps:                       nil,
+	Guess:                              dartGuess,
+	InstallReplitNixSystemDependencies: nix.DefaultInstallReplitNixSystemDependencies,
 }

--- a/internal/backends/dotnet/dotnet.go
+++ b/internal/backends/dotnet/dotnet.go
@@ -3,6 +3,7 @@ package dotnet
 
 import (
 	"github.com/replit/upm/internal/api"
+	"github.com/replit/upm/internal/nix"
 	"github.com/replit/upm/internal/util"
 )
 
@@ -28,4 +29,5 @@ var DotNetBackend = api.LanguageBackend{
 	Quirks: api.QuirksAddRemoveAlsoLocks |
 		api.QuirksAddRemoveAlsoInstalls |
 		api.QuirksLockAlsoInstalls,
+	InstallReplitNixSystemDependencies: nix.DefaultInstallReplitNixSystemDependencies,
 }

--- a/internal/backends/elisp/elisp.go
+++ b/internal/backends/elisp/elisp.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/replit/upm/internal/api"
+	"github.com/replit/upm/internal/nix"
 	"github.com/replit/upm/internal/util"
 )
 
@@ -236,4 +237,5 @@ var ElispBackend = api.LanguageBackend{
 		}
 		return names, true
 	},
+	InstallReplitNixSystemDependencies: nix.DefaultInstallReplitNixSystemDependencies,
 }

--- a/internal/backends/java/java.go
+++ b/internal/backends/java/java.go
@@ -8,6 +8,7 @@ import (
 	"regexp"
 
 	"github.com/replit/upm/internal/api"
+	"github.com/replit/upm/internal/nix"
 	"github.com/replit/upm/internal/util"
 )
 
@@ -309,7 +310,8 @@ var JavaBackend = api.LanguageBackend{
 			"dependency:copy-dependencies",
 		})
 	},
-	ListSpecfile: listSpecfile,
-	ListLockfile: listLockfile,
-	Lock:         func() {},
+	ListSpecfile:                       listSpecfile,
+	ListLockfile:                       listLockfile,
+	Lock:                               func() {},
+	InstallReplitNixSystemDependencies: nix.DefaultInstallReplitNixSystemDependencies,
 }

--- a/internal/backends/nodejs/nodejs.go
+++ b/internal/backends/nodejs/nodejs.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/hashicorp/go-version"
 	"github.com/replit/upm/internal/api"
+	"github.com/replit/upm/internal/nix"
 	"github.com/replit/upm/internal/util"
 )
 
@@ -510,6 +511,7 @@ var BunBackend = api.LanguageBackend{
 		return pkgs
 	},
 	// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import
-	GuessRegexps: nodejsGuessRegexps,
-	Guess:        nodejsGuess,
+	GuessRegexps:                       nodejsGuessRegexps,
+	Guess:                              nodejsGuess,
+	InstallReplitNixSystemDependencies: nix.DefaultInstallReplitNixSystemDependencies,
 }

--- a/internal/backends/php/php.go
+++ b/internal/backends/php/php.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/replit/upm/internal/api"
+	"github.com/replit/upm/internal/nix"
 	"github.com/replit/upm/internal/util"
 )
 
@@ -262,4 +263,5 @@ var PhpComposerBackend = api.LanguageBackend{
 		util.NotImplemented()
 		return nil, false
 	},
+	InstallReplitNixSystemDependencies: nix.DefaultInstallReplitNixSystemDependencies,
 }

--- a/internal/backends/python/python.go
+++ b/internal/backends/python/python.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/BurntSushi/toml"
 	"github.com/replit/upm/internal/api"
+	"github.com/replit/upm/internal/nix"
 	"github.com/replit/upm/internal/util"
 )
 
@@ -304,6 +305,27 @@ func pythonMakeBackend(name string, python string) api.LanguageBackend {
 			`import ((?:.|\\\n)*)`,
 		}),
 		Guess: func() (map[api.PkgName]bool, bool) { return guess(python) },
+		InstallReplitNixSystemDependencies: func(pkgs []api.PkgName) {
+			for _, pkg := range pkgs {
+				deps := nix.PythonNixDeps(string(pkg))
+				cmds := nix.ReplitNixAddToNixEditorCmds(deps)
+				for _, cmd := range cmds {
+					util.RunCmd(cmd)
+				}
+			}
+
+			specfilePkgs, err := listSpecfile()
+			if err != nil {
+				return
+			}
+			for pkg := range specfilePkgs {
+				deps := nix.PythonNixDeps(string(pkg))
+				cmds := nix.ReplitNixAddToNixEditorCmds(deps)
+				for _, cmd := range cmds {
+					util.RunCmd(cmd)
+				}
+			}
+		},
 	}
 }
 

--- a/internal/backends/python/python.go
+++ b/internal/backends/python/python.go
@@ -309,9 +309,7 @@ func pythonMakeBackend(name string, python string) api.LanguageBackend {
 			for _, pkg := range pkgs {
 				deps := nix.PythonNixDeps(string(pkg))
 				cmds := nix.ReplitNixAddToNixEditorCmds(deps)
-				for _, cmd := range cmds {
-					util.RunCmd(cmd)
-				}
+				nix.RunNixEditorCmds(cmds)
 			}
 
 			specfilePkgs, err := listSpecfile()
@@ -321,9 +319,7 @@ func pythonMakeBackend(name string, python string) api.LanguageBackend {
 			for pkg := range specfilePkgs {
 				deps := nix.PythonNixDeps(string(pkg))
 				cmds := nix.ReplitNixAddToNixEditorCmds(deps)
-				for _, cmd := range cmds {
-					util.RunCmd(cmd)
-				}
+				nix.RunNixEditorCmds(cmds)
 			}
 		},
 	}

--- a/internal/backends/rlang/rlang.go
+++ b/internal/backends/rlang/rlang.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/replit/upm/internal/api"
+	"github.com/replit/upm/internal/nix"
 	"github.com/replit/upm/internal/util"
 )
 
@@ -172,4 +173,5 @@ var RlangBackend = api.LanguageBackend{
 
 		return nil, false
 	},
+	InstallReplitNixSystemDependencies: nix.DefaultInstallReplitNixSystemDependencies,
 }

--- a/internal/backends/ruby/ruby.go
+++ b/internal/backends/ruby/ruby.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/replit/upm/internal/api"
+	"github.com/replit/upm/internal/nix"
 	"github.com/replit/upm/internal/util"
 )
 
@@ -243,4 +244,5 @@ var RubyBackend = api.LanguageBackend{
 		}
 		return results, true
 	},
+	InstallReplitNixSystemDependencies: nix.DefaultInstallReplitNixSystemDependencies,
 }

--- a/internal/backends/rust/rust.go
+++ b/internal/backends/rust/rust.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/BurntSushi/toml"
 	"github.com/replit/upm/internal/api"
+	"github.com/replit/upm/internal/nix"
 	"github.com/replit/upm/internal/util"
 )
 
@@ -260,4 +261,5 @@ var RustBackend = api.LanguageBackend{
 		util.NotImplemented()
 		return nil, false
 	},
+	InstallReplitNixSystemDependencies: nix.DefaultInstallReplitNixSystemDependencies,
 }

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -297,6 +297,16 @@ func DoCLI() {
 	}
 	rootCmd.AddCommand(cmdShowPackageDir)
 
+	cmdInstallReplitNixSystemDependencies := &cobra.Command{
+		Use:   `install-replit-nix-system-dependencies "PACKAGE[ SPEC]" ...`,
+		Short: "Install system dependencies into replit.nix using the passed packages and the specfile.",
+		Run: func(cmd *cobra.Command, args []string) {
+			pkgSpecStrs := args
+			runInstallReplitNixSystemDependencies(language, pkgSpecStrs)
+		},
+	}
+	rootCmd.AddCommand(cmdInstallReplitNixSystemDependencies)
+
 	specialArgs := map[string](func()){}
 	for _, helpFlag := range []string{"-help", "-?"} {
 		specialArgs[helpFlag] = func() {

--- a/internal/nix/nix.go
+++ b/internal/nix/nix.go
@@ -68,3 +68,23 @@ func ReplitNixAddToNixEditorCmds(replitNixAdd ReplitNixAdd) [][]string {
 
 	return result
 }
+
+func RunNixEditorCmds(cmds [][]string) {
+	for _, cmd := range cmds {
+		output := util.GetCmdOutput(cmd)
+
+		var nixEditorStatus struct {
+			Status string
+			Data   string
+		}
+
+		if err := json.Unmarshal(output, &nixEditorStatus); err != nil {
+			util.Die("unexpected nix-editor output: %s", err)
+		}
+		if nixEditorStatus.Status != "success" {
+			util.Die("nix-editor error: %s", nixEditorStatus.Data)
+		}
+		// otherwise we have success and don't need to output
+		// anything
+	}
+}

--- a/internal/nix/nix.go
+++ b/internal/nix/nix.go
@@ -1,0 +1,70 @@
+package nix
+
+import (
+	_ "embed"
+	"encoding/json"
+	"log"
+	"os"
+	"path"
+
+	"github.com/replit/upm/internal/api"
+	"github.com/replit/upm/internal/util"
+)
+
+type ReplitNixAdd struct {
+	Deps              []string `json:"deps,omitempty"`
+	PythonLibraryDeps []string `json:"libdeps,omitempty"`
+}
+
+var (
+	python_map_var map[string]ReplitNixAdd
+
+	python_map_var_loaded bool
+
+	//go:embed python_map.json
+	python_map_json []byte
+)
+
+func DefaultInstallReplitNixSystemDependencies([]api.PkgName) {
+	// do nothing by default, if the language doesn't implement a system
+	// dependency mapping, there is no work to be done.
+}
+
+func python_map() map[string]ReplitNixAdd {
+	if python_map_var_loaded {
+		return python_map_var
+	}
+	err := json.Unmarshal(python_map_json, &python_map_var)
+	if err != nil {
+		log.Fatal("Error during Unmarshal(): ", err)
+	}
+	python_map_var_loaded = true
+	return python_map_var
+}
+
+func PythonNixDeps(pack string) ReplitNixAdd {
+	val, ok := python_map()[pack]
+	if !ok {
+		return ReplitNixAdd{}
+	}
+	return val
+}
+
+func ReplitNixAddToNixEditorCmds(replitNixAdd ReplitNixAdd) [][]string {
+	result := [][]string{}
+	repl_home := os.Getenv("REPL_HOME")
+	if repl_home == "" {
+		util.Die("REPL_HOME was not set")
+	}
+	path := path.Join(repl_home, "replit.nix")
+
+	for _, dep := range replitNixAdd.Deps {
+		result = append(result, []string{"nix-editor", "--path", path, "--add", dep})
+	}
+
+	for _, dep := range replitNixAdd.PythonLibraryDeps {
+		result = append(result, []string{"nix-editor", "--path", path, "--dep-type", "python", "--add", dep})
+	}
+
+	return result
+}

--- a/internal/nix/nix_test.go
+++ b/internal/nix/nix_test.go
@@ -1,7 +1,6 @@
 package nix
 
 import (
-	"os"
 	"testing"
 
 	assert "github.com/stretchr/testify/assert"
@@ -11,12 +10,12 @@ func TestNixPythonMap(t *testing.T) {
 	deps := PythonNixDeps("pycairo")
 
 	assert.Equal(t,
-		&ReplitNixAdd{
+		ReplitNixAdd{
 			Deps: []string{
 				"pkgs.pkg-config",
 				"pkgs.cairo",
 			},
-			PythonLibraryDeps: []string{},
+			PythonLibraryDeps: nil,
 		},
 		deps)
 }
@@ -32,18 +31,13 @@ func TestReplitNixAddToNixEditorCmds(t *testing.T) {
 		},
 	}
 
-	err := os.Setenv("REPL_HOME", "/tmp")
-	assert.NoError(t, err)
+	cmds := ReplitNixAddToNixEditorOps(*deps)
 
-	cmds := ReplitNixAddToNixEditorCmds(*deps)
-
-	expected := [][]string{
-		[]string{"nix-editor", "--path", "/tmp/replit.nix", "--add", "pkgs.pkg-config"},
-		[]string{"nix-editor", "--path", "/tmp/replit.nix", "--add", "pkgs.cairo"},
-		[]string{"nix-editor", "--path", "/tmp/replit.nix", "--dep-type", "python", "--add", "pkgs.lib"},
+	expected := []NixEditorOp{
+		{Op: "add", DepType: Regular, Dep: "pkgs.pkg-config"},
+		{Op: "add", DepType: Regular, Dep: "pkgs.cairo"},
+		{Op: "add", DepType: Python, Dep: "pkgs.lib"},
 	}
 
 	assert.Equal(t, expected, cmds)
 }
-
-// func integration test with python add calling nix adds

--- a/internal/nix/nix_test.go
+++ b/internal/nix/nix_test.go
@@ -1,0 +1,49 @@
+package nix
+
+import (
+	"os"
+	"testing"
+
+	assert "github.com/stretchr/testify/assert"
+)
+
+func TestNixPythonMap(t *testing.T) {
+	deps := PythonNixDeps("pycairo")
+
+	assert.Equal(t,
+		&ReplitNixAdd{
+			Deps: []string{
+				"pkgs.pkg-config",
+				"pkgs.cairo",
+			},
+			PythonLibraryDeps: []string{},
+		},
+		deps)
+}
+
+func TestReplitNixAddToNixEditorCmds(t *testing.T) {
+	deps := &ReplitNixAdd{
+		Deps: []string{
+			"pkgs.pkg-config",
+			"pkgs.cairo",
+		},
+		PythonLibraryDeps: []string{
+			"pkgs.lib",
+		},
+	}
+
+	err := os.Setenv("REPL_HOME", "/tmp")
+	assert.NoError(t, err)
+
+	cmds := ReplitNixAddToNixEditorCmds(deps)
+
+	expected := [][]string{
+		[]string{"nix-editor", "--path", "/tmp/replit.nix", "--add", "pkgs.pkg-config"},
+		[]string{"nix-editor", "--path", "/tmp/replit.nix", "--add", "pkgs.cairo"},
+		[]string{"nix-editor", "--path", "/tmp/replit.nix", "--dep-type", "python", "--add", "pkgs.lib"},
+	}
+
+	assert.Equal(t, expected, cmds)
+}
+
+// func integration test with python add calling nix adds

--- a/internal/nix/nix_test.go
+++ b/internal/nix/nix_test.go
@@ -35,7 +35,7 @@ func TestReplitNixAddToNixEditorCmds(t *testing.T) {
 	err := os.Setenv("REPL_HOME", "/tmp")
 	assert.NoError(t, err)
 
-	cmds := ReplitNixAddToNixEditorCmds(deps)
+	cmds := ReplitNixAddToNixEditorCmds(*deps)
 
 	expected := [][]string{
 		[]string{"nix-editor", "--path", "/tmp/replit.nix", "--add", "pkgs.pkg-config"},

--- a/internal/nix/python_map.json
+++ b/internal/nix/python_map.json
@@ -1,0 +1,5 @@
+{
+  "pycairo": {"deps": [ "pkgs.pkg-config", "pkgs.cairo" ]},
+  "moviepy": {"deps": [ "pkgs.ffmpeg", "pkgs.imagemagickBig" ]},
+  "psycopg2": {"deps": [ "pkgs.postgresql" ], "libdeps": ["pkgs.postgresql"]}
+}

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,13 +1,15 @@
 {
   nixpkgs,
+  nix-editor,
   rev,
   self,
   system,
 }: let
   pkgs = nixpkgs.legacyPackages.${system};
+  nix-editor-pkg = nix-editor.packages.${system}.nix-editor;
 in rec {
   default = upm;
-  devShell = pkgs.callPackage ./devshell {};
+  devShell = pkgs.callPackage ./devshell {nix-editor = nix-editor-pkg;};
   fmt = pkgs.callPackage ./fmt {};
   upm = pkgs.callPackage ./upm {inherit rev;};
 }

--- a/nix/devshell/default.nix
+++ b/nix/devshell/default.nix
@@ -4,6 +4,7 @@
   mkShell,
   nodejs,
   nodePackages,
+  nix-editor,
 }:
 mkShell {
   name = "upm";
@@ -13,5 +14,6 @@ mkShell {
     nodejs
     nodePackages.pnpm
     nodePackages.yarn
+    nix-editor
   ];
 }

--- a/nix/upm/default.nix
+++ b/nix/upm/default.nix
@@ -10,16 +10,17 @@ buildGoModule rec {
   src = builtins.path {
     name = "${pname}-${version}-src";
     path = ../../.;
-    filter = path: _: builtins.all (block: (builtins.baseNameOf path) != block) [
-      ".github"
-      ".semaphore"
-      "packaging"
-      "scripts"
-      "test-suite"
-      ".goreleaser.yml"
-      ".replit"
-      "replit.nix"
-    ];
+    filter = path: _:
+      builtins.all (block: (builtins.baseNameOf path) != block) [
+        ".github"
+        ".semaphore"
+        "packaging"
+        "scripts"
+        "test-suite"
+        ".goreleaser.yml"
+        ".replit"
+        "replit.nix"
+      ];
   };
 
   vendorHash = "sha256-5cOkreCEBctEu0OJ2BMfXtBJBm4C2Bi3D1RnNxsn8kQ=";


### PR DESCRIPTION
Why
===
* When installing Python packages, we want to add system dependencies to replit.nix, so the packages work.
* This can eventually be expanded to other languages too.

What changed
===
* Introduce InstallReplitNixSystemDependencies subcommand. The subcommand uses the language specfile and packages sent on the commandline (the new ones we're adding) to determine what it should try to look up in the system dependency map.
* Make a default function that does nothing for all languages except Python
* For Python, add a python_map.json that maps package names to system dependency install operations and embed in go
* Add tests for functions that translate the map into nix-editor ops

Test plan
===
* Remove replit.nix so we have a blank slate to start
* Make a pyproject.toml file like
```
[tool.poetry.dependencies]
python = ">=3.10.0,<3.11"
psycopg2 = "^1.26.0"
```
* run `REPL_HOME=. go run ./cmd/upm install-replit-nix-system-dependencies`
* Confirm the replit.nix file has a postgres dep in the deps and and python ld library path.
* run `REPL_HOME=. go run ./cmd/upm install-replit-nix-system-dependencies pycairo`
* Confirm that cairo and pkg-config are added to deps