### PR TITLE
Fix upm-on-replit

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,6 +1,6 @@
 run = "make && echo \"UPM is built, can be found here: ./cmd/upm/upm\""
 
-modules = ["go"]
+modules = ["go-1.20:v2-20230911-b5aa5df"]
 
 [nix]
 channel = "stable-23_05" # Only channel with go 1.17

--- a/.replit
+++ b/.replit
@@ -1,10 +1,6 @@
 run = "make && echo \"UPM is built, can be found here: ./cmd/upm/upm\""
 
+modules = ["go"]
+
 [nix]
-channel = "stable-21_11" # Only channel with go 1.17
-
-[languages.go]
-pattern = "**/*.go"
-
-[languages.go.languageServer]
-start = "gopls"
+channel = "stable-23_05" # Only channel with go 1.17

--- a/replit.nix
+++ b/replit.nix
@@ -3,7 +3,6 @@
     pkgs.golangci-lint
     pkgs.wget
     pkgs.gnumake
-    pkgs.go_1_20
     pkgs.gopls
     pkgs.gcc
     pkgs.curl

--- a/replit.nix
+++ b/replit.nix
@@ -1,5 +1,6 @@
 {pkgs}: {
   deps = [
+    pkgs.golangci-lint
     pkgs.wget
     pkgs.gnumake
     pkgs.go_1_20
@@ -11,12 +12,12 @@
     pkgs.maven
     pkgs.emacs-nox
     pkgs.cask
-    pkgs.nodejs-16_x
+    pkgs.nodejs-18_x
     pkgs.yarn
     pkgs.nodePackages.pnpm
-    pkgs.python39Full
-    pkgs.python39Packages.pip
-    pkgs.python39Packages.poetry
+    pkgs.python310Full
+    pkgs.python310Packages.pip
+    pkgs.poetry
     pkgs.R
     pkgs.ruby
     pkgs.sqlite


### PR DESCRIPTION
# What Changed 

update nix channel
update packages (including go)
use go module

# Test plan

On replit 

```
$ mkdir testnpm
$ cd testnpm
$ npm init -y
$ ../cmd/upm/upm add left-pad -l nodejs-npm
```

Works
