### PR TITLE
remove useless comment

### DIFF
--- a/.replit
+++ b/.replit
@@ -3,4 +3,4 @@ run = "make && echo \"UPM is built, can be found here: ./cmd/upm/upm\""
 modules = ["go-1.20:v2-20230911-b5aa5df"]
 
 [nix]
-channel = "stable-23_05" # Only channel with go 1.17
+channel = "stable-23_05"


### PR DESCRIPTION
Comment referenced 1.17, we're on 1.20. But in any case, we get the go binary from the go module not the nix channel.