### PR TITLE
fix upm panics in install-replit-nix-system-dependencies subcommand

### DIFF
--- a/internal/backends/nodejs/nodejs.go
+++ b/internal/backends/nodejs/nodejs.go
@@ -305,8 +305,9 @@ var NodejsYarnBackend = api.LanguageBackend{
 		return pkgs
 	},
 	// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import
-	GuessRegexps: nodejsGuessRegexps,
-	Guess:        nodejsGuess,
+	GuessRegexps:                       nodejsGuessRegexps,
+	Guess:                              nodejsGuess,
+	InstallReplitNixSystemDependencies: nix.DefaultInstallReplitNixSystemDependencies,
 }
 
 var NodejsPNPMBackend = api.LanguageBackend{
@@ -386,8 +387,9 @@ var NodejsPNPMBackend = api.LanguageBackend{
 		return pkgs
 	},
 	// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import
-	GuessRegexps: nodejsGuessRegexps,
-	Guess:        nodejsGuess,
+	GuessRegexps:                       nodejsGuessRegexps,
+	Guess:                              nodejsGuess,
+	InstallReplitNixSystemDependencies: nix.DefaultInstallReplitNixSystemDependencies,
 }
 
 // NodejsNPMBackend is a UPM backend for Node.js that uses NPM.
@@ -448,8 +450,9 @@ var NodejsNPMBackend = api.LanguageBackend{
 		return pkgs
 	},
 	// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import
-	GuessRegexps: nodejsGuessRegexps,
-	Guess:        nodejsGuess,
+	GuessRegexps:                       nodejsGuessRegexps,
+	Guess:                              nodejsGuess,
+	InstallReplitNixSystemDependencies: nix.DefaultInstallReplitNixSystemDependencies,
 }
 
 // BunBackend is a UPM backend for Node.js that uses Yarn.

--- a/test-suite/install_replit_nix_system_dependencies_test.go
+++ b/test-suite/install_replit_nix_system_dependencies_test.go
@@ -1,0 +1,25 @@
+package testSuite
+
+import (
+	"os"
+	"testing"
+
+	testUtils "github.com/replit/upm/test-suite/utils"
+)
+
+func TestInstallReplitNixSystemDependencies(t *testing.T) {
+	for _, bt := range languageBackends {
+		bt.Start(t)
+
+		bt.Subtest(bt.Backend.Name, doInstallReplitNixSystemDependencies)
+	}
+}
+
+func doInstallReplitNixSystemDependencies(bt testUtils.BackendT) {
+	os.Setenv("REPL_HOME", ".")
+	for _, tmpl := range standardTemplates {
+		bt.Subtest(tmpl, func(bt testUtils.BackendT) {
+			bt.UpmInstallReplitNixSystemDependencies()
+		})
+	}
+}

--- a/test-suite/utils/upm.go
+++ b/test-suite/utils/upm.go
@@ -331,3 +331,16 @@ func (bt *BackendT) UpmWhichLanguage() {
 		bt.Fail("expected %s, got %s", bt.Backend.Name, detected)
 	}
 }
+
+func (bt *BackendT) UpmInstallReplitNixSystemDependencies() {
+	_, err := bt.Exec(
+		"upm",
+		"--lang",
+		bt.Backend.Name,
+		"install-replit-nix-system-dependencies",
+	)
+
+	if err != nil {
+		bt.Fail("upm failed to install-replit-nix-system-dependencies: %v", err)
+	}
+}


### PR DESCRIPTION
Why
===
* certain nodejs backends were missing the function needed for the install-replit-nix-system-dependencies subcommand and this was causing panics.

What changed
===
* Add a super-basic integration test for upm install-replit-nix-system-dependencies that calls it for all backends/templates
* The test doesn't really check anything except that the command runs without failing.
* I confirmed this test fails for the nodejs backends with problems
* Add the missing install-replit-nix-system-dependencies hook for the backends that were missing it

Test plan
===
* make test-suite