### PR TITLE
python_map: add mysqlclient, pyzbar sort

### DIFF
--- a/internal/nix/python_map.json
+++ b/internal/nix/python_map.json
@@ -1,5 +1,7 @@
 {
-  "pycairo": {"deps": [ "pkgs.pkg-config", "pkgs.cairo" ]},
   "moviepy": {"deps": [ "pkgs.ffmpeg", "pkgs.imagemagickBig" ]},
-  "psycopg2": {"deps": [ "pkgs.postgresql" ], "libdeps": ["pkgs.postgresql"]}
+  "mysqlclient": {"deps": [ "pkgs.pkg-config", "pkgs.libmysqlclient" ]},
+  "psycopg2": {"deps": [ "pkgs.postgresql" ], "libdeps": ["pkgs.postgresql"]},
+  "pycairo": {"deps": [ "pkgs.pkg-config", "pkgs.cairo" ]},
+  "pyzbar": {"libdeps": ["pkgs.zbar"]}
 }


### PR DESCRIPTION
Why
===
* We need more system dependency map entries to make it useful.

What changed
===
* Sorted the list
* Added pyzbar
* Added mysqlclient

Test plan
===
* confirm Nix unit tests still pass: go test -v -race ./internal/nix/...