### PR TITLE
add explicit require test to js guess tests

### DIFF
--- a/test-suite/Guess_test.go
+++ b/test-suite/Guess_test.go
@@ -33,6 +33,7 @@ func TestGuess(t *testing.T) {
 					"dedup",
 					"nested",
 					"esparse-fail",
+					"require",
 				}
 			}
 

--- a/test-suite/templates/guess/js/require
+++ b/test-suite/templates/guess/js/require
@@ -1,0 +1,2 @@
+const foo = require("express");
+require('@sveltejs/adapter-auto')

--- a/test-suite/templates/guess/js/require.expect
+++ b/test-suite/templates/guess/js/require.expect
@@ -1,0 +1,2 @@
+express
+@sveltejs/adapter-auto


### PR DESCRIPTION
just realized the only test using `require` is in dedup