### PR TITLE
add Alias field to backends, support at CLI and store levels

### DIFF
--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -143,6 +143,10 @@ type LanguageBackend struct {
 	// This field is mandatory.
 	Name string
 
+	// An alias for the backend, useful for backwards compatibility
+	// when renaming backends.
+	Alias string
+
 	// The filename of the specfile, e.g. "pyproject.toml" for
 	// Poetry.
 	//

--- a/internal/backends/backends.go
+++ b/internal/backends/backends.go
@@ -54,6 +54,7 @@ func matchesLanguage(b api.LanguageBackend, language string) bool {
 	for _, lPart := range strings.Split(language, "-") {
 		if !bParts[lPart] {
 			checkAlias = true
+			break
 		}
 	}
 	if checkAlias {

--- a/internal/backends/backends.go
+++ b/internal/backends/backends.go
@@ -50,9 +50,21 @@ func matchesLanguage(b api.LanguageBackend, language string) bool {
 	for _, bPart := range strings.Split(b.Name, "-") {
 		bParts[bPart] = true
 	}
+	checkAlias := false
 	for _, lPart := range strings.Split(language, "-") {
 		if !bParts[lPart] {
-			return false
+			checkAlias = true
+		}
+	}
+	if checkAlias {
+		bParts = map[string]bool{}
+		for _, bPart := range strings.Split(b.Name, "-") {
+			bParts[bPart] = true
+		}
+		for _, lPart := range strings.Split(language, "-") {
+			if !bParts[lPart] {
+				return false
+			}
 		}
 	}
 	return true

--- a/internal/backends/backends.go
+++ b/internal/backends/backends.go
@@ -58,7 +58,7 @@ func matchesLanguage(b api.LanguageBackend, language string) bool {
 	}
 	if checkAlias {
 		bParts = map[string]bool{}
-		for _, bPart := range strings.Split(b.Name, "-") {
+		for _, bPart := range strings.Split(b.Alias, "-") {
 			bParts[bPart] = true
 		}
 		for _, lPart := range strings.Split(language, "-") {

--- a/internal/backends/python/python.go
+++ b/internal/backends/python/python.go
@@ -185,6 +185,7 @@ func add(pkgs map[api.PkgName]api.PkgSpec, projectName string) {
 func makePythonPoetryBackend(python string) api.LanguageBackend {
 	return api.LanguageBackend{
 		Name:             "python3-poetry",
+		Alias:            "python-python3-poetry",
 		Specfile:         "pyproject.toml",
 		Lockfile:         "poetry.lock",
 		FilenamePatterns: []string{"*.py"},

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -70,7 +70,7 @@ func initLanguage(language, languageAlias string) {
 	if st.Languages == nil {
 		st.Languages = map[string]*storeLanguage{}
 	}
-	if st.Languages[language] == nil && (languageAlias != "" || st.Languages[languageAlias] == nil) {
+	if st.Languages[language] == nil && (languageAlias == "" || st.Languages[languageAlias] == nil) {
 		st.Languages[language] = &storeLanguage{}
 	}
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -70,7 +70,7 @@ func initLanguage(language, languageAlias string) {
 	if st.Languages == nil {
 		st.Languages = map[string]*storeLanguage{}
 	}
-	if st.Languages[language] == nil && languageAlias != "" && st.Languages[languageAlias] != nil {
+	if st.Languages[language] == nil && languageAlias != "" && st.Languages[languageAlias] == nil {
 		st.Languages[language] = &storeLanguage{}
 	}
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -66,13 +66,26 @@ func readMaybe() {
 
 // initLanguage creates an entry in the store for the given language,
 // if necessary. (A language is just the name of a backend.)
-func initLanguage(language string) {
+func initLanguage(language, languageAlias string) {
 	if st.Languages == nil {
 		st.Languages = map[string]*storeLanguage{}
 	}
-	if st.Languages[language] == nil {
+	if st.Languages[language] == nil && languageAlias != "" && st.Languages[languageAlias] != nil {
 		st.Languages[language] = &storeLanguage{}
 	}
+}
+
+func getLanguageCache(language, languageAlias string) *storeLanguage {
+	if st.Languages == nil {
+		return nil
+	}
+	if st.Languages[language] != nil {
+		return st.Languages[language]
+	}
+	if languageAlias != "" && st.Languages[languageAlias] != nil {
+		return st.Languages[languageAlias]
+	}
+	return nil
 }
 
 // Write writes the current contents of the store from memory back to
@@ -105,8 +118,8 @@ func Write() {
 // returns true.
 func HasSpecfileChanged(b api.LanguageBackend) bool {
 	readMaybe()
-	initLanguage(b.Name)
-	return hashFile(b.Specfile) != st.Languages[b.Name].SpecfileHash
+	initLanguage(b.Name, b.Alias)
+	return hashFile(b.Specfile) != getLanguageCache(b.Name, b.Alias).SpecfileHash
 }
 
 // HasLockfileChanged returns false if the lockfile exists and has not
@@ -115,8 +128,8 @@ func HasSpecfileChanged(b api.LanguageBackend) bool {
 // returns true.
 func HasLockfileChanged(b api.LanguageBackend) bool {
 	readMaybe()
-	initLanguage(b.Name)
-	return hashFile(b.Lockfile) != st.Languages[b.Name].LockfileHash
+	initLanguage(b.Name, b.Alias)
+	return hashFile(b.Lockfile) != getLanguageCache(b.Name, b.Alias).LockfileHash
 }
 
 // GuessWithCache returns b.Guess(), but re-uses a cached return value
@@ -129,14 +142,15 @@ func HasLockfileChanged(b api.LanguageBackend) bool {
 // not read from the cache.
 func GuessWithCache(b api.LanguageBackend, forceGuess bool) map[api.PkgName]bool {
 	readMaybe()
-	initLanguage(b.Name)
-	old := st.Languages[b.Name].GuessedImportsHash
+	initLanguage(b.Name, b.Alias)
+	cache := getLanguageCache(b.Name, b.Alias)
+	old := cache.GuessedImportsHash
 	var new hash = "n/a"
 	// If no regexps, then we can't hash imports. Skip reading and
 	// writing the hash.
 	if len(b.GuessRegexps) > 0 {
 		new = hashImports(b)
-		st.Languages[b.Name].GuessedImportsHash = new
+		cache.GuessedImportsHash = new
 	}
 	if forceGuess || new != old {
 		var pkgs map[api.PkgName]bool
@@ -157,7 +171,7 @@ func GuessWithCache(b api.LanguageBackend, forceGuess bool) map[api.PkgName]bool
 			// e.g. due to syntax error, then don't update
 			// the hash. This will force the search to be
 			// redone next time.
-			st.Languages[b.Name].GuessedImportsHash = old
+			cache.GuessedImportsHash = old
 		}
 		// Only cache result if we are going to use the cache,
 		// and skip caching if bare imports search was not
@@ -172,12 +186,12 @@ func GuessWithCache(b api.LanguageBackend, forceGuess bool) map[api.PkgName]bool
 			for name := range pkgs {
 				guessed = append(guessed, string(name))
 			}
-			st.Languages[b.Name].GuessedImports = guessed
+			cache.GuessedImports = guessed
 		}
 		return pkgs
 	} else {
 		pkgs := map[api.PkgName]bool{}
-		for _, name := range st.Languages[b.Name].GuessedImports {
+		for _, name := range cache.GuessedImports {
 			pkgs[api.PkgName(name)] = true
 		}
 		return pkgs
@@ -188,7 +202,8 @@ func GuessWithCache(b api.LanguageBackend, forceGuess bool) map[api.PkgName]bool
 // lockfile. Neither file need exist.
 func UpdateFileHashes(b api.LanguageBackend) {
 	readMaybe()
-	initLanguage(b.Name)
-	st.Languages[b.Name].SpecfileHash = hashFile(b.Specfile)
-	st.Languages[b.Name].LockfileHash = hashFile(b.Lockfile)
+	initLanguage(b.Name, b.Alias)
+	cache := getLanguageCache(b.Name, b.Alias)
+	cache.SpecfileHash = hashFile(b.Specfile)
+	cache.LockfileHash = hashFile(b.Lockfile)
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -70,7 +70,7 @@ func initLanguage(language, languageAlias string) {
 	if st.Languages == nil {
 		st.Languages = map[string]*storeLanguage{}
 	}
-	if st.Languages[language] == nil && languageAlias != "" && st.Languages[languageAlias] == nil {
+	if st.Languages[language] == nil && (languageAlias != "" || st.Languages[languageAlias] == nil) {
 		st.Languages[language] = &storeLanguage{}
 	}
 }


### PR DESCRIPTION
# Why

#147 made a couple of breaking changes to the CLI:
- removed `python-python2-poetry` backend
- simplified `python-python3-poetry` backend name to `python3-poetry`

unfortunately, the latter change will cause all upm caches to be invalidated, and invocations of `upm -l python-python3-poetry` will break.

# What changed

- Added `Alias` field to `api.LanguageBackend`
- When resolving the backend via `-l` flag, if resolving via `Name` of the `LanguageBackend` fails, try to resolve against the `Alias`
- The logic for reading from the cache store is now:
  - check if there's a match for `Name`, if there is then use that cache
  - check if there's a match for `Alias`, if there is then use that cache
- The logic for creating a cache entry in the store is now:
  - check if there's a match for `Name`, exit function if true
  - check if there's a match for `Alias`, exit function if true
  - create an entry for `Name`