### PR TITLE
ignore all packages in /test-suite for packagers we test

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  # https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#package-ecosystem
+  # TODO: https://github.com/dependabot/dependabot-core/issues/4364
+  - directory: "/test-suite"
+    package-ecosystem: "npm"
+    ignore: "*"
+  - directory: "/test-suite"
+    package-ecosystem: "pnpm"
+    ignore: "*"
+  - directory: "/test-suite"
+    package-ecosystem: "poetry"
+    ignore: "*"
+  - directory: "/test-suite"
+    package-ecosystem: "yarn"
+    ignore: "*"


### PR DESCRIPTION
it's annoying getting dependabot PRs because we don't even actively use these packages. this will help minimize disk usage (by keeping the packages Eternally Pinned, we don't download ♾️ versions of packages just to run some tests), reduce unnecessary maintenance burden, and enhance predictability in our test suite.

note that dependabot doesn't have a way to blanket-ignore a directory. super annoying. tracked by https://github.com/dependabot/dependabot-core/issues/4364. this means we'll have to remember to go to https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#package-ecosystem every time we test another backend, and remember to update the dependabot.yml file. 