### PR TITLE
UPM log file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/mattn/go-sqlite3 v1.14.17
 	github.com/natefinch/atomic v0.0.0-20150920032501-a62ce929ffcc
+	github.com/sirupsen/logrus v1.9.3
 	github.com/smacker/go-tree-sitter v0.0.0-20230501083651-a7d92773b3aa
 	github.com/spf13/cobra v0.0.5
 	github.com/stretchr/testify v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -114,6 +114,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
+github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
+github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/smacker/go-tree-sitter v0.0.0-20230501083651-a7d92773b3aa h1:exZ0FwfhblsYbgfqYH+W/3sFye821WD02NjBmc+ENhE=
 github.com/smacker/go-tree-sitter v0.0.0-20230501083651-a7d92773b3aa/go.mod h1:q99oHDsbP0xRwmn7Vmob8gbSMNyvJ83OauXPSuHQuKE=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
@@ -128,6 +130,7 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.4/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
@@ -175,6 +178,7 @@ golang.org/x/sys v0.0.0-20181205085412-a5c9d58dba9a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.7.0 h1:3jlCCIQZPdOYu1h8BkNvLz8Kgwtae2cagcG/VamtZRU=
 golang.org/x/sys v0.7.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.7.0 h1:BEvjmm5fURWqcfbSKTdpkDXYBrUS1c0m8agp14W48vQ=

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -3,11 +3,13 @@ package cli
 
 import (
 	"fmt"
+	"io"
 	"os"
 
 	"github.com/replit/upm/internal/backends"
 	"github.com/replit/upm/internal/config"
 	"github.com/replit/upm/internal/util"
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -35,9 +37,26 @@ func getVersion() string {
 	return "upm " + version
 }
 
+var logFilePath = "/tmp/upm.log"
+
 // DoCLI reads the command-line arguments and runs the appropriate
 // code, then exits the process (or returns to indicate normal exit).
 func DoCLI() {
+
+	// Setup logging
+	log.SetFormatter(&log.JSONFormatter{})
+	if os.Getenv("UPM_TRACE") == "1" {
+		logFile, err := os.Create(logFilePath)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to create %s\n", logFilePath)
+			return
+		}
+		defer logFile.Close()
+		log.SetOutput(logFile)
+	} else {
+		log.SetOutput(io.Discard)
+	}
+
 	backends.SetupAll()
 
 	var language string

--- a/nix/upm/default.nix
+++ b/nix/upm/default.nix
@@ -24,7 +24,7 @@ buildGoModule rec {
       ];
   };
 
-  vendorHash = "sha256-QTTRRUBS7XKCRyNgZ1HMSll5EHjVuJgSpqgOzRbg7yo=";
+  vendorHash = "sha256-z41yF4TWkHRZVZ7SSBBiU9cAnDY2fWTzKaJJ94KbSrQ=";
 
   ldflags = [
     "-X github.com/replit/upm/internal/cli.version=${rev}"

--- a/nix/upm/default.nix
+++ b/nix/upm/default.nix
@@ -24,7 +24,7 @@ buildGoModule rec {
       ];
   };
 
-  vendorHash = "sha256-z41yF4TWkHRZVZ7SSBBiU9cAnDY2fWTzKaJJ94KbSrQ=";
+  vendorHash = "sha256-ItX5re7cIvKCbtnSSbeJUSW1IdefFTKKB2O03/2RG3Y=";
 
   ldflags = [
     "-X github.com/replit/upm/internal/cli.version=${rev}"


### PR DESCRIPTION
# Why?

Want to log to Datadog.

## Changes

1. Added logrus
2. Configured logrus to write to `/tmp/upm.log` if `UPM_TRACE` is `1`. No logging otherwise.
3. Added logging of timing information for upm guess and upm lock
4. Added additional timing information for python and node.js guesses

## Testing

1. `UPM_TRACE=1 upm lock` or `UPM_TRACE=1 upm guess -l python -f` should produce a `/tmp/upm.log` in line-json format