### PR TITLE
fix dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,13 +4,13 @@ updates:
   # TODO: https://github.com/dependabot/dependabot-core/issues/4364
   - directory: "/test-suite"
     package-ecosystem: "npm"
-    ignore: "*"
+    schedule:
+      interval: "monthly"
+    ignore:
+    - dependency-name: "*"
   - directory: "/test-suite"
-    package-ecosystem: "pnpm"
-    ignore: "*"
-  - directory: "/test-suite"
-    package-ecosystem: "poetry"
-    ignore: "*"
-  - directory: "/test-suite"
-    package-ecosystem: "yarn"
-    ignore: "*"
+    package-ecosystem: "pip"
+    schedule:
+      interval: "monthly"
+    ignore:
+    - dependency-name: "*"


### PR DESCRIPTION
it's annoying and apparently the config i set up before was full of errors. this time i had my yaml extension working so it validated against the schema, and i double-checked the docs. hopefully dependabot schema checker for CI kicks in on this PR as affirmation that we won't get stupid dependabot PRs anymore