### PR TITLE
Datadog msgs log to /tmp/upm.log

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -10,7 +10,6 @@ import (
 	"github.com/replit/upm/internal/trace"
 	"github.com/replit/upm/internal/util"
 	"github.com/spf13/cobra"
-	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 )
 
 // parseOutputFormat takes "table" or "json" and returns an
@@ -40,9 +39,11 @@ func getVersion() string {
 // DoCLI reads the command-line arguments and runs the appropriate
 // code, then exits the process (or returns to indicate normal exit).
 func DoCLI() {
-	if trace.MaybeTrace(getVersion()) {
-		defer tracer.Stop()
+	cleanupFn := trace.MaybeTrace(getVersion())
+	if cleanupFn != nil {
+		defer cleanupFn()
 	}
+
 	backends.SetupAll()
 
 	var language string

--- a/internal/trace/logger.go
+++ b/internal/trace/logger.go
@@ -1,0 +1,27 @@
+package trace
+
+import "os"
+
+type DatadogLogger struct {
+	file *os.File
+}
+
+func NewDatadogLogger() (*DatadogLogger, error) {
+	file, err := os.Create("/tmp/upm.dd.log")
+	if err != nil {
+		return nil, err
+	}
+
+	return &DatadogLogger{
+		file: file,
+	}, nil
+}
+
+func (l *DatadogLogger) Log(msg string) {
+	l.file.WriteString(msg)
+	l.file.WriteString("\n")
+}
+
+func (l *DatadogLogger) Close() {
+	l.file.Close()
+}

--- a/internal/trace/logger.go
+++ b/internal/trace/logger.go
@@ -18,8 +18,7 @@ func NewDatadogLogger() (*DatadogLogger, error) {
 }
 
 func (l *DatadogLogger) Log(msg string) {
-	l.file.WriteString(msg)
-	l.file.WriteString("\n")
+	_, _ = l.file.WriteString(msg + "\n")
 }
 
 func (l *DatadogLogger) Close() {


### PR DESCRIPTION
# Why?

Don't want to [display DD logs](https://github.com/replit/goval/pull/11405) to the console.

## Changes

This writes them in `/tmp/upm.dd.log`