### PR TITLE
don't sample; send all data

### DIFF
--- a/internal/trace/trace.go
+++ b/internal/trace/trace.go
@@ -35,7 +35,7 @@ func MaybeTrace(serviceVersion string) func() {
 
 	rules := []tracer.SamplingRule{
 		// send 100.00% of traces
-		tracer.ServiceRule("upm", 1.0000),
+		tracer.ServiceRule("upm", 1.0),
 	}
 	tracer.Start()
 

--- a/internal/trace/trace.go
+++ b/internal/trace/trace.go
@@ -37,7 +37,6 @@ func MaybeTrace(serviceVersion string) func() {
 		// send 100.00% of traces
 		tracer.ServiceRule("upm", 1.0),
 	}
-	tracer.Start()
 
 	tracer.Start(
 		tracer.WithService("upm"),

--- a/internal/trace/trace.go
+++ b/internal/trace/trace.go
@@ -33,11 +33,18 @@ func MaybeTrace(serviceVersion string) func() {
 		return nil
 	}
 
+	rules := []tracer.SamplingRule{
+		// send 100.00% of traces
+		tracer.ServiceRule("upm", 1.0000),
+	}
+	tracer.Start()
+
 	tracer.Start(
 		tracer.WithService("upm"),
 		tracer.WithGlobalTag("replid", replid),
 		tracer.WithServiceVersion(serviceVersion),
 		tracer.WithLogger(logger),
+		tracer.WithSamplingRules(rules),
 	)
 	return func() {
 		tracer.Stop()


### PR DESCRIPTION
# Why?

We found that the dd-agent samples our traces down to ~20%. To better diagnose an issue of missing spans we are going to send all data from Repls where instrumentation is on.

# Changes

add rule to "sample" 100% of data.