### PR TITLE
[python map] add reflex

### DIFF
--- a/internal/nix/python_map.json
+++ b/internal/nix/python_map.json
@@ -597,6 +597,7 @@
   "ray":{"deps":["pkgs.py-spy"]},
   "rchitect":{"deps":["pkgs.R"],"libdeps":["pkgs.R"]},
   "rdkit":{"deps":["pkgs.cairo","pkgs.catch2","pkgs.comic-neue","pkgs.coordgenlibs","pkgs.eigen","pkgs.inchi","pkgs.maeparser","pkgs.rapidjson"],"libdeps":["pkgs.cairo","pkgs.catch2","pkgs.coordgenlibs","pkgs.inchi","pkgs.maeparser","pkgs.rapidjson"]},
+  "reflex":{"deps":["pkgs.unzip"]},
   "reportengine":{"deps":["pkgs.pandoc"]},
   "reportlab":{"deps":["pkgs.freetype","pkgs.glibcLocales"],"libdeps":["pkgs.freetype","pkgs.glibcLocales"]},
   "requests-credssp":{"deps":["pkgs.krb5"],"libdeps":["pkgs.krb5"]},


### PR DESCRIPTION
Why
===
* We found that reflex init needs unzip to work

What changed
===
* Added unzip

Test plan
===
* go test ./internal/nix/... still works
* on replit, try installing reflex and observe unzip in replit.nix