### PR TITLE
check regex match results when looking for a pragma

### DIFF
--- a/internal/util/tree-sitter.go
+++ b/internal/util/tree-sitter.go
@@ -164,6 +164,10 @@ var pragmaRegex = regexp.MustCompile(`upm (?:package\((?P<package>.*)\))`)
 func parsePragma(pragma string) importPragma {
 	caps := pragmaRegex.FindStringSubmatch(pragma)
 
+	if len(caps) == 0 {
+		return importPragma{}
+	}
+
 	return importPragma{
 		Package: caps[pragmaRegex.SubexpIndex("package")],
 	}

--- a/test-suite/templates/guess/py/basic
+++ b/test-suite/templates/guess/py/basic
@@ -1,3 +1,4 @@
 from django.shortcuts import render
+# this is an arbitrary comment
 from flask import Flask
 import replit.ai


### PR DESCRIPTION
# why

upm was panicking due to index-out-of-range when checking for upm pragmas. turns out the code as-is expects there to _always_ be a valid pragma if there's just a comment associated with the import line

# what changed

when reading captures for the upm pragma, check that there's a regexp match in the first place

# test plan

tests pass