### PR TITLE
feat/Ignore packages in SortNoop

### DIFF
--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -205,7 +205,7 @@ type LanguageBackend struct {
 
 	// Apply a sensible heuristic for sorting search results
 	// if we know we want to surface some packages over others.
-	SortPackages func(query string, ignoredPackages []string, packages []PkgInfo) []PkgInfo
+	SortPackages func(query string, packages []PkgInfo) []PkgInfo
 
 	// Search for packages using an online index. The query may
 	// contain any characters, including whitespace. Return a list

--- a/internal/backends/dart/dart.go
+++ b/internal/backends/dart/dart.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/replit/upm/internal/api"
 	"github.com/replit/upm/internal/nix"
-	"github.com/replit/upm/internal/pkg"
 	"github.com/replit/upm/internal/util"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 	"gopkg.in/yaml.v2"
@@ -302,7 +301,6 @@ var DartPubBackend = api.LanguageBackend{
 	FilenamePatterns: []string{"*.dart"},
 	Quirks:           api.QuirksLockAlsoInstalls,
 	GetPackageDir:    dartGetPackageDir,
-	SortPackages:     pkg.SortNoop(pkg.NormalizePackageNameNoop),
 	Search:           dartSearch,
 	Info:             dartInfo,
 	Add:              dartAdd,

--- a/internal/backends/dart/dart.go
+++ b/internal/backends/dart/dart.go
@@ -302,7 +302,7 @@ var DartPubBackend = api.LanguageBackend{
 	FilenamePatterns: []string{"*.dart"},
 	Quirks:           api.QuirksLockAlsoInstalls,
 	GetPackageDir:    dartGetPackageDir,
-	SortPackages:     pkg.SortNoop,
+	SortPackages:     pkg.SortNoop(pkg.NormalizePackageNameNoop),
 	Search:           dartSearch,
 	Info:             dartInfo,
 	Add:              dartAdd,

--- a/internal/backends/dotnet/dotnet.go
+++ b/internal/backends/dotnet/dotnet.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/replit/upm/internal/api"
 	"github.com/replit/upm/internal/nix"
-	"github.com/replit/upm/internal/pkg"
 	"github.com/replit/upm/internal/util"
 )
 
@@ -22,7 +21,6 @@ var DotNetBackend = api.LanguageBackend{
 	Add: func(ctx context.Context, pkgs map[api.PkgName]api.PkgSpec, projectName string) {
 		addPackages(ctx, pkgs, projectName, util.RunCmd)
 	},
-	SortPackages: pkg.SortNoop(pkg.NormalizePackageNameNoop),
 	Search:       search,
 	Info:         info,
 	Install:      func(ctx context.Context) { install(ctx, util.RunCmd) },

--- a/internal/backends/dotnet/dotnet.go
+++ b/internal/backends/dotnet/dotnet.go
@@ -22,7 +22,7 @@ var DotNetBackend = api.LanguageBackend{
 	Add: func(ctx context.Context, pkgs map[api.PkgName]api.PkgSpec, projectName string) {
 		addPackages(ctx, pkgs, projectName, util.RunCmd)
 	},
-	SortPackages: pkg.SortNoop,
+	SortPackages: pkg.SortNoop(pkg.NormalizePackageNameNoop),
 	Search:       search,
 	Info:         info,
 	Install:      func(ctx context.Context) { install(ctx, util.RunCmd) },

--- a/internal/backends/elisp/elisp.go
+++ b/internal/backends/elisp/elisp.go
@@ -30,7 +30,7 @@ var ElispBackend = api.LanguageBackend{
 	GetPackageDir: func() string {
 		return ".cask"
 	},
-	SortPackages: pkg.SortNoop,
+	SortPackages: pkg.SortNoop(pkg.NormalizePackageNameNoop),
 	Search: func(query string) []api.PkgInfo {
 		tmpdir, err := os.MkdirTemp("", "elpa")
 		if err != nil {

--- a/internal/backends/elisp/elisp.go
+++ b/internal/backends/elisp/elisp.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/replit/upm/internal/api"
 	"github.com/replit/upm/internal/nix"
-	"github.com/replit/upm/internal/pkg"
 	"github.com/replit/upm/internal/util"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 )
@@ -30,7 +29,6 @@ var ElispBackend = api.LanguageBackend{
 	GetPackageDir: func() string {
 		return ".cask"
 	},
-	SortPackages: pkg.SortNoop(pkg.NormalizePackageNameNoop),
 	Search: func(query string) []api.PkgInfo {
 		tmpdir, err := os.MkdirTemp("", "elpa")
 		if err != nil {

--- a/internal/backends/java/java.go
+++ b/internal/backends/java/java.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/replit/upm/internal/api"
 	"github.com/replit/upm/internal/nix"
-	"github.com/replit/upm/internal/pkg"
 	"github.com/replit/upm/internal/util"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 )
@@ -308,11 +307,10 @@ var JavaBackend = api.LanguageBackend{
 	GetPackageDir: func() string {
 		return "target/dependency"
 	},
-	SortPackages: pkg.SortNoop(pkg.NormalizePackageNameNoop),
-	Search:       search,
-	Info:         info,
-	Add:          addPackages,
-	Remove:       removePackages,
+	Search: search,
+	Info:   info,
+	Add:    addPackages,
+	Remove: removePackages,
 	Install: func(ctx context.Context) {
 		//nolint:ineffassign,wastedassign,staticcheck
 		span, ctx := tracer.StartSpanFromContext(ctx, "Maven install")

--- a/internal/backends/java/java.go
+++ b/internal/backends/java/java.go
@@ -308,7 +308,7 @@ var JavaBackend = api.LanguageBackend{
 	GetPackageDir: func() string {
 		return "target/dependency"
 	},
-	SortPackages: pkg.SortNoop,
+	SortPackages: pkg.SortNoop(pkg.NormalizePackageNameNoop),
 	Search:       search,
 	Info:         info,
 	Add:          addPackages,

--- a/internal/backends/nodejs/nodejs.go
+++ b/internal/backends/nodejs/nodejs.go
@@ -274,7 +274,7 @@ var NodejsYarnBackend = api.LanguageBackend{
 	GetPackageDir: func() string {
 		return "node_modules"
 	},
-	SortPackages: pkg.SortNoop,
+	SortPackages: pkg.SortNoop(pkg.NormalizePackageNameNoop),
 	Search:       nodejsSearch,
 	Info:         nodejsInfo,
 	Add: func(ctx context.Context, pkgs map[api.PkgName]api.PkgSpec, projectName string) {
@@ -350,7 +350,7 @@ var NodejsPNPMBackend = api.LanguageBackend{
 	GetPackageDir: func() string {
 		return "node_modules"
 	},
-	SortPackages: pkg.SortNoop,
+	SortPackages: pkg.SortNoop(pkg.NormalizePackageNameNoop),
 	Search:       nodejsSearch,
 	Info:         nodejsInfo,
 	Add: func(ctx context.Context, pkgs map[api.PkgName]api.PkgSpec, projectName string) {
@@ -444,7 +444,7 @@ var NodejsNPMBackend = api.LanguageBackend{
 	GetPackageDir: func() string {
 		return "node_modules"
 	},
-	SortPackages: pkg.SortNoop,
+	SortPackages: pkg.SortNoop(pkg.NormalizePackageNameNoop),
 	Search:       nodejsSearch,
 	Info:         nodejsInfo,
 	Add: func(ctx context.Context, pkgs map[api.PkgName]api.PkgSpec, projectName string) {
@@ -527,7 +527,7 @@ var BunBackend = api.LanguageBackend{
 	GetPackageDir: func() string {
 		return "node_modules"
 	},
-	SortPackages: pkg.SortNoop,
+	SortPackages: pkg.SortNoop(pkg.NormalizePackageNameNoop),
 	Search:       nodejsSearch,
 	Info:         nodejsInfo,
 	Add: func(ctx context.Context, pkgs map[api.PkgName]api.PkgSpec, projectName string) {

--- a/internal/backends/nodejs/nodejs.go
+++ b/internal/backends/nodejs/nodejs.go
@@ -14,7 +14,6 @@ import (
 	"github.com/hashicorp/go-version"
 	"github.com/replit/upm/internal/api"
 	"github.com/replit/upm/internal/nix"
-	"github.com/replit/upm/internal/pkg"
 	"github.com/replit/upm/internal/util"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 	"gopkg.in/yaml.v2"
@@ -274,9 +273,8 @@ var NodejsYarnBackend = api.LanguageBackend{
 	GetPackageDir: func() string {
 		return "node_modules"
 	},
-	SortPackages: pkg.SortNoop(pkg.NormalizePackageNameNoop),
-	Search:       nodejsSearch,
-	Info:         nodejsInfo,
+	Search: nodejsSearch,
+	Info:   nodejsInfo,
 	Add: func(ctx context.Context, pkgs map[api.PkgName]api.PkgSpec, projectName string) {
 		//nolint:ineffassign,wastedassign,staticcheck
 		span, ctx := tracer.StartSpanFromContext(ctx, "yarn (init) add")
@@ -350,9 +348,8 @@ var NodejsPNPMBackend = api.LanguageBackend{
 	GetPackageDir: func() string {
 		return "node_modules"
 	},
-	SortPackages: pkg.SortNoop(pkg.NormalizePackageNameNoop),
-	Search:       nodejsSearch,
-	Info:         nodejsInfo,
+	Search: nodejsSearch,
+	Info:   nodejsInfo,
 	Add: func(ctx context.Context, pkgs map[api.PkgName]api.PkgSpec, projectName string) {
 		//nolint:ineffassign,wastedassign,staticcheck
 		span, ctx := tracer.StartSpanFromContext(ctx, "pnpm (init) add")
@@ -444,9 +441,8 @@ var NodejsNPMBackend = api.LanguageBackend{
 	GetPackageDir: func() string {
 		return "node_modules"
 	},
-	SortPackages: pkg.SortNoop(pkg.NormalizePackageNameNoop),
-	Search:       nodejsSearch,
-	Info:         nodejsInfo,
+	Search: nodejsSearch,
+	Info:   nodejsInfo,
 	Add: func(ctx context.Context, pkgs map[api.PkgName]api.PkgSpec, projectName string) {
 		//nolint:ineffassign,wastedassign,staticcheck
 		span, ctx := tracer.StartSpanFromContext(ctx, "npm (init) install")
@@ -527,9 +523,8 @@ var BunBackend = api.LanguageBackend{
 	GetPackageDir: func() string {
 		return "node_modules"
 	},
-	SortPackages: pkg.SortNoop(pkg.NormalizePackageNameNoop),
-	Search:       nodejsSearch,
-	Info:         nodejsInfo,
+	Search: nodejsSearch,
+	Info:   nodejsInfo,
 	Add: func(ctx context.Context, pkgs map[api.PkgName]api.PkgSpec, projectName string) {
 		//nolint:ineffassign,wastedassign,staticcheck
 		span, ctx := tracer.StartSpanFromContext(ctx, "bun (init) add")

--- a/internal/backends/php/php.go
+++ b/internal/backends/php/php.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/replit/upm/internal/api"
 	"github.com/replit/upm/internal/nix"
-	"github.com/replit/upm/internal/pkg"
 	"github.com/replit/upm/internal/util"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 )
@@ -233,9 +232,8 @@ var PhpComposerBackend = api.LanguageBackend{
 	GetPackageDir: func() string {
 		return "vendor"
 	},
-	SortPackages: pkg.SortNoop(pkg.NormalizePackageNameNoop),
-	Search:       search,
-	Info:         info,
+	Search: search,
+	Info:   info,
 	Add: func(ctx context.Context, pkgs map[api.PkgName]api.PkgSpec, projectVendorName string) {
 		//nolint:ineffassign,wastedassign,staticcheck
 		span, ctx := tracer.StartSpanFromContext(ctx, "composer require")

--- a/internal/backends/php/php.go
+++ b/internal/backends/php/php.go
@@ -233,7 +233,7 @@ var PhpComposerBackend = api.LanguageBackend{
 	GetPackageDir: func() string {
 		return "vendor"
 	},
-	SortPackages: pkg.SortNoop,
+	SortPackages: pkg.SortNoop(pkg.NormalizePackageNameNoop),
 	Search:       search,
 	Info:         info,
 	Add: func(ctx context.Context, pkgs map[api.PkgName]api.PkgSpec, projectVendorName string) {

--- a/internal/backends/python/python.go
+++ b/internal/backends/python/python.go
@@ -257,8 +257,8 @@ func makePythonPoetryBackend(python string) api.LanguageBackend {
 
 			return filepath.Join(path, base+"-py"+version)
 		},
-		SortPackages: func(query string, ignoredPackages []string, packages []api.PkgInfo) []api.PkgInfo {
-			return pkg.SortPrefixSuffix(normalizePackageName, query, ignoredPackages, packages)
+		SortPackages: func(query string, packages []api.PkgInfo) []api.PkgInfo {
+			return pkg.SortPrefixSuffix(normalizePackageName, query, packages)
 		},
 
 		Search: func(query string) []api.PkgInfo {

--- a/internal/backends/python/python.go
+++ b/internal/backends/python/python.go
@@ -257,9 +257,7 @@ func makePythonPoetryBackend(python string) api.LanguageBackend {
 
 			return filepath.Join(path, base+"-py"+version)
 		},
-		SortPackages: func(query string, packages []api.PkgInfo) []api.PkgInfo {
-			return pkg.SortPrefixSuffix(normalizePackageName, query, packages)
-		},
+		SortPackages: pkg.SortPrefixSuffix(normalizePackageName),
 
 		Search: func(query string) []api.PkgInfo {
 			results, err := SearchPypi(query)

--- a/internal/backends/rlang/rlang.go
+++ b/internal/backends/rlang/rlang.go
@@ -85,7 +85,7 @@ var RlangBackend = api.LanguageBackend{
 	FilenamePatterns: []string{"*.r", "*.R"},
 	Quirks:           api.QuirksNone,
 	GetPackageDir:    getRPkgDir,
-	SortPackages:     pkg.SortNoop,
+	SortPackages:     pkg.SortNoop(pkg.NormalizePackageNameNoop),
 	Search: func(query string) []api.PkgInfo {
 		pkgs := []api.PkgInfo{}
 		for _, hit := range SearchPackages(query) {

--- a/internal/backends/rlang/rlang.go
+++ b/internal/backends/rlang/rlang.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/replit/upm/internal/api"
 	"github.com/replit/upm/internal/nix"
-	"github.com/replit/upm/internal/pkg"
 	"github.com/replit/upm/internal/util"
 )
 
@@ -85,7 +84,6 @@ var RlangBackend = api.LanguageBackend{
 	FilenamePatterns: []string{"*.r", "*.R"},
 	Quirks:           api.QuirksNone,
 	GetPackageDir:    getRPkgDir,
-	SortPackages:     pkg.SortNoop(pkg.NormalizePackageNameNoop),
 	Search: func(query string) []api.PkgInfo {
 		pkgs := []api.PkgInfo{}
 		for _, hit := range SearchPackages(query) {

--- a/internal/backends/ruby/ruby.go
+++ b/internal/backends/ruby/ruby.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/replit/upm/internal/api"
 	"github.com/replit/upm/internal/nix"
-	"github.com/replit/upm/internal/pkg"
 	"github.com/replit/upm/internal/util"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 )
@@ -81,7 +80,6 @@ var RubyBackend = api.LanguageBackend{
 			return path
 		}
 	},
-	SortPackages: pkg.SortNoop(pkg.NormalizePackageNameNoop),
 	Search: func(query string) []api.PkgInfo {
 		endpoint := "https://rubygems.org/api/v1/search.json"
 		queryParams := "?query=" + url.QueryEscape(query)

--- a/internal/backends/ruby/ruby.go
+++ b/internal/backends/ruby/ruby.go
@@ -81,7 +81,7 @@ var RubyBackend = api.LanguageBackend{
 			return path
 		}
 	},
-	SortPackages: pkg.SortNoop,
+	SortPackages: pkg.SortNoop(pkg.NormalizePackageNameNoop),
 	Search: func(query string) []api.PkgInfo {
 		endpoint := "https://rubygems.org/api/v1/search.json"
 		queryParams := "?query=" + url.QueryEscape(query)

--- a/internal/backends/rust/rust.go
+++ b/internal/backends/rust/rust.go
@@ -229,7 +229,7 @@ var RustBackend = api.LanguageBackend{
 	GetPackageDir: func() string {
 		return "target"
 	},
-	SortPackages: pkg.SortNoop,
+	SortPackages: pkg.SortNoop(pkg.NormalizePackageNameNoop),
 	Search:       search,
 	Info:         info,
 	Add: func(ctx context.Context, pkgs map[api.PkgName]api.PkgSpec, projectName string) {

--- a/internal/backends/rust/rust.go
+++ b/internal/backends/rust/rust.go
@@ -11,7 +11,6 @@ import (
 	"github.com/BurntSushi/toml"
 	"github.com/replit/upm/internal/api"
 	"github.com/replit/upm/internal/nix"
-	"github.com/replit/upm/internal/pkg"
 	"github.com/replit/upm/internal/util"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 )
@@ -229,9 +228,8 @@ var RustBackend = api.LanguageBackend{
 	GetPackageDir: func() string {
 		return "target"
 	},
-	SortPackages: pkg.SortNoop(pkg.NormalizePackageNameNoop),
-	Search:       search,
-	Info:         info,
+	Search: search,
+	Info:   info,
 	Add: func(ctx context.Context, pkgs map[api.PkgName]api.PkgSpec, projectName string) {
 		//nolint:ineffassign,wastedassign,staticcheck
 		span, ctx := tracer.StartSpanFromContext(ctx, "cargo add")

--- a/internal/cli/cmds.go
+++ b/internal/cli/cmds.go
@@ -91,7 +91,9 @@ func runSearch(language string, args []string, outputFormat outputFormat, ignore
 	}
 
 	// Apply some heuristics to give results that more closely resemble the user's query
-	results = b.SortPackages(query, results)
+	if b.SortPackages != nil {
+		results = b.SortPackages(query, results)
+	}
 
 	// Output a reasonable number of results.
 	if len(results) > 20 {

--- a/internal/cli/cmds.go
+++ b/internal/cli/cmds.go
@@ -54,6 +54,16 @@ func runListLanguages() {
 	}
 }
 
+func makeLoweredHM(normalizePackageName func(api.PkgName) api.PkgName, names []string) map[api.PkgName]bool {
+	// Build a hashset. struct{}{} purportedly is of size 0, so this is as good as we get
+	set := make(map[api.PkgName]bool)
+	for _, pkg := range names {
+		normal := normalizePackageName(api.PkgName(pkg))
+		set[normal] = true
+	}
+	return set
+}
+
 // runSearch implements 'upm search'.
 func runSearch(language string, args []string, outputFormat outputFormat, ignoredPackages []string) {
 	query := strings.Join(args, " ")
@@ -66,8 +76,22 @@ func runSearch(language string, args []string, outputFormat outputFormat, ignore
 		results = b.Search(query)
 	}
 
+	{ // Filter out ignored packages
+		ignoredPackageSet := makeLoweredHM(b.NormalizePackageName, ignoredPackages)
+		filtered := []api.PkgInfo{}
+		for _, pkg := range results {
+			lower := b.NormalizePackageName(api.PkgName(pkg.Name))
+			if ignoredPackageSet[lower] {
+				continue
+			}
+			filtered = append(filtered, pkg)
+		}
+
+		results = filtered
+	}
+
 	// Apply some heuristics to give results that more closely resemble the user's query
-	results = b.SortPackages(query, ignoredPackages, results)
+	results = b.SortPackages(query, results)
 
 	// Output a reasonable number of results.
 	if len(results) > 20 {

--- a/internal/pkg/pkg.go
+++ b/internal/pkg/pkg.go
@@ -5,20 +5,6 @@ import (
 	"github.com/replit/upm/internal/api"
 )
 
-func NormalizePackageNameNoop(name api.PkgName) api.PkgName {
-	return name
-}
-
-func SortNoop(normalizePackageName func(api.PkgName) api.PkgName) func(query string, packages []api.PkgInfo) []api.PkgInfo {
-	return func(query string, packages []api.PkgInfo) []api.PkgInfo {
-		return sortNoop(normalizePackageName, query, packages)
-	}
-}
-
-func sortNoop(normalizePackageName func(api.PkgName) api.PkgName, query string, packages []api.PkgInfo) []api.PkgInfo {
-	return packages
-}
-
 func SortPrefixSuffix(normalizePackageName func(api.PkgName) api.PkgName) func(query string, packages []api.PkgInfo) []api.PkgInfo {
 	return func(query string, packages []api.PkgInfo) []api.PkgInfo {
 		return sortPrefixSuffix(normalizePackageName, query, packages)

--- a/internal/pkg/pkg.go
+++ b/internal/pkg/pkg.go
@@ -5,23 +5,11 @@ import (
 	"github.com/replit/upm/internal/api"
 )
 
-func SortNoop(query string, ignoredPackages []string, packages []api.PkgInfo) []api.PkgInfo {
+func SortNoop(query string, packages []api.PkgInfo) []api.PkgInfo {
 	return packages
 }
 
-func makeLoweredHM(normalizePackageName func(api.PkgName) api.PkgName, names []string) map[api.PkgName]bool {
-	// Build a hashset. struct{}{} purportedly is of size 0, so this is as good as we get
-	set := make(map[api.PkgName]bool)
-	for _, pkg := range names {
-		normal := normalizePackageName(api.PkgName(pkg))
-		set[normal] = true
-	}
-	return set
-}
-
-func SortPrefixSuffix(normalizePackageName func(api.PkgName) api.PkgName, query string, ignoredPackages []string, packages []api.PkgInfo) []api.PkgInfo {
-	ignoredPackageSet := makeLoweredHM(normalizePackageName, ignoredPackages)
-
+func SortPrefixSuffix(normalizePackageName func(api.PkgName) api.PkgName, query string, packages []api.PkgInfo) []api.PkgInfo {
 	needle := normalizePackageName(api.PkgName(query))
 	var exact *api.PkgInfo
 	prefixed := []api.PkgInfo{}
@@ -33,8 +21,6 @@ func SortPrefixSuffix(normalizePackageName func(api.PkgName) api.PkgName, query 
 		lower := normalizePackageName(api.PkgName(pkg.Name))
 		if lower == needle {
 			exact = &packages[idx]
-		} else if ignoredPackageSet[lower] {
-			continue
 		} else if lower.HasPrefix(needle) {
 			prefixed = append(prefixed, pkg)
 		} else if lower.Contains(needle) {

--- a/internal/pkg/pkg.go
+++ b/internal/pkg/pkg.go
@@ -5,11 +5,27 @@ import (
 	"github.com/replit/upm/internal/api"
 )
 
-func SortNoop(query string, packages []api.PkgInfo) []api.PkgInfo {
+func NormalizePackageNameNoop(name api.PkgName) api.PkgName {
+	return name
+}
+
+func SortNoop(normalizePackageName func(api.PkgName) api.PkgName) func(query string, packages []api.PkgInfo) []api.PkgInfo {
+	return func(query string, packages []api.PkgInfo) []api.PkgInfo {
+		return sortNoop(normalizePackageName, query, packages)
+	}
+}
+
+func sortNoop(normalizePackageName func(api.PkgName) api.PkgName, query string, packages []api.PkgInfo) []api.PkgInfo {
 	return packages
 }
 
-func SortPrefixSuffix(normalizePackageName func(api.PkgName) api.PkgName, query string, packages []api.PkgInfo) []api.PkgInfo {
+func SortPrefixSuffix(normalizePackageName func(api.PkgName) api.PkgName) func(query string, packages []api.PkgInfo) []api.PkgInfo {
+	return func(query string, packages []api.PkgInfo) []api.PkgInfo {
+		return sortPrefixSuffix(normalizePackageName, query, packages)
+	}
+}
+
+func sortPrefixSuffix(normalizePackageName func(api.PkgName) api.PkgName, query string, packages []api.PkgInfo) []api.PkgInfo {
 	needle := normalizePackageName(api.PkgName(query))
 	var exact *api.PkgInfo
 	prefixed := []api.PkgInfo{}

--- a/internal/pkg/pkg_test.go
+++ b/internal/pkg/pkg_test.go
@@ -30,9 +30,7 @@ func TestSortNoop(t *testing.T) {
 		})
 	}
 
-	ignoredPackages := []string{"foo2"}
-
-	sorted := SortNoop("foo", ignoredPackages, pkgs)
+	sorted := SortNoop("foo", pkgs)
 
 	expected := names
 
@@ -70,13 +68,12 @@ func TestSortPrefixSuffix(t *testing.T) {
 		})
 	}
 
-	ignoredPackages := []string{"foo2"}
-
-	sorted := SortPrefixSuffix(simpleNormalizePackageName, "foo", ignoredPackages, pkgs)
+	sorted := SortPrefixSuffix(simpleNormalizePackageName, "foo", pkgs)
 
 	expected := []string{
 		"foo",
 		"foo-bar",
+		"foo2",
 		"foo-baz",
 		"foo-blix",
 		"borp-foo",

--- a/internal/pkg/pkg_test.go
+++ b/internal/pkg/pkg_test.go
@@ -7,40 +7,6 @@ import (
 	"github.com/replit/upm/internal/api"
 )
 
-func TestSortNoop(t *testing.T) {
-	names := []string{
-		"borp-foo",
-		"beep-foo",
-		"foo-bar",
-		"a-foo-b",
-		"unrelated",
-		"c-foo-d",
-		"foo",
-		"also-unrelated",
-		"foo2",
-		"foo-baz",
-		"foo-blix",
-	}
-
-	pkgs := []api.PkgInfo{}
-
-	for _, name := range names {
-		pkgs = append(pkgs, api.PkgInfo{
-			Name: name,
-		})
-	}
-
-	sorted := SortNoop(NormalizePackageNameNoop)("foo", pkgs)
-
-	expected := names
-
-	for idx, pkg := range sorted {
-		if string(pkg.Name) != expected[idx] {
-			t.Errorf("Unexpected package ordering: %s != %s", pkg.Name, expected[idx])
-		}
-	}
-}
-
 func simpleNormalizePackageName(name api.PkgName) api.PkgName {
 	return api.PkgName(strings.ToLower(string(name)))
 }

--- a/internal/pkg/pkg_test.go
+++ b/internal/pkg/pkg_test.go
@@ -30,7 +30,7 @@ func TestSortNoop(t *testing.T) {
 		})
 	}
 
-	sorted := SortNoop("foo", pkgs)
+	sorted := SortNoop(NormalizePackageNameNoop)("foo", pkgs)
 
 	expected := names
 
@@ -68,7 +68,7 @@ func TestSortPrefixSuffix(t *testing.T) {
 		})
 	}
 
-	sorted := SortPrefixSuffix(simpleNormalizePackageName, "foo", pkgs)
+	sorted := SortPrefixSuffix(simpleNormalizePackageName)("foo", pkgs)
 
 	expected := []string{
 		"foo",


### PR DESCRIPTION
This got overlooked in review comments from #169 

- Delete `SortNoop`
- Promote `--ignored-packages` to top-level, so all backends get it for free