### PR TITLE
[store] if store.json is empty, don't try to unmarshal it

### DIFF
--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/replit/upm/internal/api"
 	"github.com/replit/upm/internal/util"
@@ -50,8 +51,10 @@ func read() {
 		util.Die("%s: %s", filename, err)
 	}
 
-	if err = json.Unmarshal(bytes, st); err != nil {
-		util.Die("%s: %s", filename, err)
+	if len(strings.TrimSpace(string(bytes))) > 0 {
+		if err = json.Unmarshal(bytes, st); err != nil {
+			util.Die("%s: %s", filename, err)
+		}
 	}
 
 	if st.Version != currentVersion {


### PR DESCRIPTION
Why
===
* We're seeing many error logs with

> store.json: unexpected end of JSON input

* Looking at the Repls, it appears they have an empty store.json file

What changed
===
* If the store.json file is empty, skip unmarshalling and assume it is empty

Test plan
===
* ran `UPM_STORE=store.json ./result/bin/upm -l nodejs add express` with an empty store.json file before and after the change