### PR TITLE
[ci] fix lint

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -47,5 +47,5 @@ blocks:
             - cache restore golangci-lint
             - >-
               curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh
-              | sh -s -- -b /tmp v1.52.2
+              | sh -s -- -b /tmp v1.55.2
             - /tmp/golangci-lint run

--- a/nix/devshell/default.nix
+++ b/nix/devshell/default.nix
@@ -7,16 +7,18 @@
   nix-editor,
   poetry,
   python311Full,
+  golangci-lint,
 }:
 mkShell {
   name = "upm";
   packages = [
     bun
     go
+    golangci-lint
+    nix-editor
     nodejs
     nodePackages.pnpm
     nodePackages.yarn
-    nix-editor
     poetry
     python311Full
   ];


### PR DESCRIPTION
Why
===
* CI lint was broken in https://replit.semaphoreci.com/jobs/e535bc22-e0fe-4f4f-bd11-97b4e856a801
* Upgrading golangci-lint might fix it, since it looks like the problems were for the wrong version of Go

What changed
===
* Bump version go golangci-lint we install in CI

Test plan
===
* This CI run