### PR TITLE
[poetry] Make show-package-dir work again

### DIFF
--- a/internal/backends/python/python.go
+++ b/internal/backends/python/python.go
@@ -221,7 +221,7 @@ func makePythonPoetryBackend(python string) api.LanguageBackend {
 
 			outputB, err := util.GetCmdOutputFallible([]string{
 				"poetry",
-				"config", "settings.virtualenvs.path",
+				"config", "virtualenvs.path",
 			})
 			if err != nil {
 				// there's no virtualenv configured, so no package directory
@@ -229,9 +229,7 @@ func makePythonPoetryBackend(python string) api.LanguageBackend {
 			}
 
 			var path string
-			if err := json.Unmarshal(outputB, &path); err != nil {
-				util.Die("parsing output from Poetry: %s", err)
-			}
+			path = strings.TrimSpace(string(outputB))
 
 			base := ""
 			if util.Exists("pyproject.toml") {

--- a/internal/cli/cmds.go
+++ b/internal/cli/cmds.go
@@ -585,7 +585,9 @@ func runShowLockfile(language string) {
 func runShowPackageDir(language string) {
 	b := backends.GetBackend(context.Background(), language)
 	dir := b.GetPackageDir()
-	fmt.Println(dir)
+	if dir != "" {
+		fmt.Println(dir)
+	}
 }
 
 // runInstallReplitNixSystemDependencies implements 'upm install-replit-nix-system-dependencies'.


### PR DESCRIPTION
Remove manual reimplementation of poetry's venv location logic in favor of just emitting nothing if the directory doesn't exist.

Previous logic had drifted away from how poetry actually works. If the previous spec'd behavior is desired, we can open a change against poetry itself to surface this information, or attempt to use poetry as a library to get access to internals.