### PR TITLE
Permit individual suites

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,6 +95,15 @@ test-suite:
 else
 test-suite:
 	nix develop -c nix shell -c go test -run $(GO_TEST_RUN_OPTS) ./test-suite
+
+test-%:
+	nix develop -c nix shell -c make wrapped-$@
+
+wrapped-test-%:
+	suite_prefix="$$(echo "$@" | cut -d- -f 3-)"; \
+	echo "Running $$suite_prefix"; \
+	cd test-suite; \
+	UPM_SUITE_PREFIX="$$suite_prefix" go test
 endif
 
 fmt:

--- a/test-suite/Main_test.go
+++ b/test-suite/Main_test.go
@@ -2,6 +2,8 @@ package testSuite
 
 import (
 	"context"
+	"os"
+	"strings"
 
 	"github.com/replit/upm/internal/backends"
 	"github.com/replit/upm/test-suite/templates"
@@ -20,6 +22,10 @@ func init() {
 	backends.SetupAll()
 
 	for _, bn := range backends.GetBackendNames() {
+		prefix := os.Getenv("UPM_SUITE_PREFIX")
+		if !strings.HasPrefix(bn, prefix) {
+			continue
+		}
 		bt := testUtils.InitBackendT(backends.GetBackend(context.Background(), bn), &templates.FS)
 		languageBackends = append(languageBackends, bt)
 	}

--- a/test-suite/Main_test.go
+++ b/test-suite/Main_test.go
@@ -2,6 +2,7 @@ package testSuite
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"strings"
 
@@ -21,12 +22,15 @@ var standardTemplates = []string{
 func init() {
 	backends.SetupAll()
 
+	fmt.Println("Preparing test suites:")
 	for _, bn := range backends.GetBackendNames() {
 		prefix := os.Getenv("UPM_SUITE_PREFIX")
 		if !strings.HasPrefix(bn, prefix) {
 			continue
 		}
+		fmt.Println("- " + bn)
 		bt := testUtils.InitBackendT(backends.GetBackend(context.Background(), bn), &templates.FS)
 		languageBackends = append(languageBackends, bt)
 	}
+	fmt.Println()
 }


### PR DESCRIPTION
Permit running individual language suites via `make test-...`

Example:

```bash
$ make test-python3  # Run all python3 backends
...
$ make test-python3-poetry  # Run only the python3-poetry backend
...
$ make test-nodejs  # Run all nodejs backends
Preparing test suites:
- nodejs-npm
- nodejs-pnpm
- nodejs-yarn
```