### PR TITLE
Fix poetry show package dir

### DIFF
--- a/internal/backends/backends.go
+++ b/internal/backends/backends.go
@@ -27,7 +27,7 @@ import (
 // If more than one backend might match the same project, then one
 // that comes first in this list will be used.
 var languageBackends = []api.LanguageBackend{
-	python.Python3Backend,
+	python.PythonPoetryBackend,
 	nodejs.BunBackend,
 	nodejs.NodejsNPMBackend,
 	nodejs.NodejsPNPMBackend,

--- a/internal/backends/nodejs/nodejs.go
+++ b/internal/backends/nodejs/nodejs.go
@@ -367,7 +367,7 @@ var tsxPathGlobs = []string{
 	"*.tsx",
 }
 
-// NodejsYarnBackend is a UPM backend for Node.js that uses Yarn.
+// NodejsYarnBackend is a UPM backend for Node.js that uses [Yarn](https://yarnpkg.com/).
 var NodejsYarnBackend = api.LanguageBackend{
 	Name:             "nodejs-yarn",
 	Specfile:         "package.json",
@@ -443,6 +443,7 @@ var NodejsYarnBackend = api.LanguageBackend{
 	InstallReplitNixSystemDependencies: nix.DefaultInstallReplitNixSystemDependencies,
 }
 
+// NodejsPNPMBackend is a UPM backend for Node.js that uses [pnpm](https://pnpm.io/).
 var NodejsPNPMBackend = api.LanguageBackend{
 	Name:             "nodejs-pnpm",
 	Specfile:         "package.json",
@@ -535,7 +536,7 @@ var NodejsPNPMBackend = api.LanguageBackend{
 	InstallReplitNixSystemDependencies: nix.DefaultInstallReplitNixSystemDependencies,
 }
 
-// NodejsNPMBackend is a UPM backend for Node.js that uses NPM.
+// NodejsNPMBackend is a UPM backend for Node.js that uses [NPM](https://npmjs.com/).
 var NodejsNPMBackend = api.LanguageBackend{
 	Name:             "nodejs-npm",
 	Specfile:         "package.json",
@@ -617,7 +618,7 @@ var NodejsNPMBackend = api.LanguageBackend{
 	InstallReplitNixSystemDependencies: nix.DefaultInstallReplitNixSystemDependencies,
 }
 
-// BunBackend is a UPM backend for Node.js that uses Yarn.
+// BunBackend is a UPM backend for Node.js that uses [Bun](https://bun.sh/).
 var BunBackend = api.LanguageBackend{
 	Name:             "bun",
 	Specfile:         "package.json",

--- a/internal/backends/python/backend_test.go
+++ b/internal/backends/python/backend_test.go
@@ -9,7 +9,7 @@ import (
 func TestNormalizePackageName(t *testing.T) {
 	// Take test cases for package normalization from official docs
 	// https://packaging.python.org/en/latest/specifications/name-normalization/#normalization
-	b := Python3Backend
+	b := PythonPoetryBackend
 
 	normalizedForm := api.PkgName("friendly-bard")
 

--- a/internal/backends/python/python.go
+++ b/internal/backends/python/python.go
@@ -221,7 +221,7 @@ func makePythonPoetryBackend(python string) api.LanguageBackend {
 
 			outputB, err := util.GetCmdOutputFallible([]string{
 				"poetry",
-				"config", "settings.virtualenvs.path",
+				"config", "virtualenvs.path",
 			})
 			if err != nil {
 				// there's no virtualenv configured, so no package directory
@@ -229,9 +229,7 @@ func makePythonPoetryBackend(python string) api.LanguageBackend {
 			}
 
 			var path string
-			if err := json.Unmarshal(outputB, &path); err != nil {
-				util.Die("parsing output from Poetry: %s", err)
-			}
+			path = strings.TrimSpace(string(outputB))
 
 			base := ""
 			if util.Exists("pyproject.toml") {

--- a/internal/backends/python/python.go
+++ b/internal/backends/python/python.go
@@ -296,7 +296,7 @@ func makePythonPoetryBackend(python string) api.LanguageBackend {
 			util.RunCmd([]string{"poetry", "install"})
 		},
 		ListSpecfile: func() map[api.PkgName]api.PkgSpec {
-			pkgs, err := listSpecfile()
+			pkgs, err := listPoetrySpecfile()
 			if err != nil {
 				util.Die("%s", err.Error())
 			}
@@ -337,7 +337,7 @@ func makePythonPoetryBackend(python string) api.LanguageBackend {
 
 			// Ignore the error here, because if we can't read the specfile,
 			// we still want to add the deps from above at least.
-			specfilePkgs, _ := listSpecfile()
+			specfilePkgs, _ := listPoetrySpecfile()
 			for pkg := range specfilePkgs {
 				deps := nix.PythonNixDeps(string(pkg))
 				ops = append(ops, nix.ReplitNixAddToNixEditorOps(deps)...)
@@ -347,7 +347,7 @@ func makePythonPoetryBackend(python string) api.LanguageBackend {
 	}
 }
 
-func listSpecfile() (map[api.PkgName]api.PkgSpec, error) {
+func listPoetrySpecfile() (map[api.PkgName]api.PkgSpec, error) {
 	var cfg pyprojectTOML
 	if _, err := toml.DecodeFile("pyproject.toml", &cfg); err != nil {
 		return nil, err
@@ -394,5 +394,5 @@ func getPython3() string {
 	}
 }
 
-// Python3Backend is a UPM backend for Python 3 that uses Poetry.
-var Python3Backend = makePythonPoetryBackend(getPython3())
+// PythonPoetryBackend is a UPM backend for Python 3 that uses Poetry.
+var PythonPoetryBackend = makePythonPoetryBackend(getPython3())

--- a/internal/cli/cmds.go
+++ b/internal/cli/cmds.go
@@ -585,7 +585,9 @@ func runShowLockfile(language string) {
 func runShowPackageDir(language string) {
 	b := backends.GetBackend(context.Background(), language)
 	dir := b.GetPackageDir()
-	fmt.Println(dir)
+	if dir != "" {
+		fmt.Println(dir)
+	}
 }
 
 // runInstallReplitNixSystemDependencies implements 'upm install-replit-nix-system-dependencies'.

--- a/internal/cli/cmds.go
+++ b/internal/cli/cmds.go
@@ -366,7 +366,7 @@ func runRemove(language string, args []string, upgrade bool,
 	for _, arg := range args {
 		name := api.PkgName(arg)
 		norm := b.NormalizePackageName(name)
-		if _, ok := normSpecfilePkgs[norm]; ok {
+		if normSpecfilePkgs[norm] {
 			normPkgs[norm] = name
 		}
 	}

--- a/test-suite/Install_test.go
+++ b/test-suite/Install_test.go
@@ -38,7 +38,10 @@ func doInstall(bt testUtils.BackendT) {
 
 			packageDirPath := bt.UpmPackageDir()
 
-			_, err := os.Stat(path.Join(bt.TestDir(), packageDirPath))
+			if !path.IsAbs(packageDirPath) {
+				packageDirPath = path.Join(bt.TestDir(), packageDirPath)
+			}
+			_, err := os.Stat(packageDirPath)
 			if err != nil {
 				bt.Fail("expected package dir to exist: %v", err)
 			}


### PR DESCRIPTION
How poetry calculates the env path has changed, so instead of trying to guess, just delegate to `poetry env`. If the environment hasn't been created we don't get a path, which is only relevant if we're in a completely blank environment, so it's hopefully not that bad.

- Renaming Python3Backend to `PythonPoetryBackend`
- Rely on `poetry env list` to find the active environment
- General housekeeping