### PR TITLE
Permit nonreproducible backends to be tested

### DIFF
--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -165,8 +165,6 @@ type LanguageBackend struct {
 
 	// The filename of the lockfile, e.g. "poetry.lock" for
 	// Poetry.
-	//
-	// This field is mandatory.
 	Lockfile string
 
 	// List of filename globs that match against files written in
@@ -284,8 +282,6 @@ type LanguageBackend struct {
 	// List the packages in the lockfile. Names should be returned
 	// in a format suitable for the Add method. The lockfile is
 	// guaranteed to exist already.
-	//
-	// This field is mandatory.
 	ListLockfile func() map[PkgName]PkgVersion
 
 	// Regexps used to determine if the Guess method really needs
@@ -343,7 +339,7 @@ func (b *LanguageBackend) Setup() {
 	condition2flag := map[string]bool{
 		"missing name":                     b.Name == "",
 		"missing specfile":                 b.Specfile == "",
-		"missing lockfile":                 b.Lockfile == "",
+		"missing lockfile":                 b.QuirksIsReproducible() && b.Lockfile == "",
 		"need at least 1 filename pattern": len(b.FilenamePatterns) == 0,
 		"missing package dir":              b.GetPackageDir == nil,
 		"missing Search":                   b.Search == nil,
@@ -355,7 +351,7 @@ func (b *LanguageBackend) Setup() {
 		"either implement Lock or mark QuirksIsNotReproducible": ((b.Lock == nil) != b.QuirksIsNotReproducible()),
 		"missing install":      b.Install == nil,
 		"missing ListSpecfile": b.ListSpecfile == nil,
-		"missing ListLockfile": b.ListLockfile == nil,
+		"missing ListLockfile": b.QuirksIsReproducible() && b.ListLockfile == nil,
 		// If the backend isn't reproducible, then lock is
 		// unimplemented. So how could it also do
 		// installation?

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -121,6 +121,10 @@ const (
 	// This constant indicates that lock also executes install
 	// subsequently, so it doesn't need to be run afterwards.
 	QuirksLockAlsoInstalls
+
+	// This constant indicates that remove cannot be performed
+	// without a lockfile.
+	QuirkRemoveNeedsLockfile
 )
 
 // LanguageBackend is the core abstraction of UPM. It represents an

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -357,7 +357,7 @@ func (b *LanguageBackend) Setup() {
 		// installation?
 		"Lock installs, but is not implemented": b.QuirksDoesLockAlsoInstall() && b.QuirksIsNotReproducible(),
 		// If you install, then you have to lock.
-		"Add and Remove install, so they must also Lock": b.QuirksDoesAddRemoveAlsoInstall() && !b.QuirksDoesAddRemoveAlsoLock(),
+		"Add and Remove install, so they must also Lock": b.QuirksIsReproducible() && b.QuirksDoesAddRemoveAlsoInstall() && b.QuirksDoesAddRemoveNotAlsoLock(),
 	}
 
 	reasons := []string{}

--- a/internal/api/util.go
+++ b/internal/api/util.go
@@ -56,3 +56,9 @@ func (b *LanguageBackend) QuirksDoesLockAlsoInstall() bool {
 func (b *LanguageBackend) QuirksDoesLockNotAlsoInstall() bool {
 	return (b.Quirks & QuirksLockAlsoInstalls) == 0
 }
+
+// QuirkRemoveNeedsLockfile returns true if the language backend
+// cannot run lock without a valid lockfile
+func (b *LanguageBackend) QuirkRemoveNeedsLockfile() bool {
+	return (b.Quirks & QuirkRemoveNeedsLockfile) != 0
+}

--- a/internal/backends/nodejs/nodejs.go
+++ b/internal/backends/nodejs/nodejs.go
@@ -375,7 +375,8 @@ var NodejsYarnBackend = api.LanguageBackend{
 	FilenamePatterns: nodejsPatterns,
 	Quirks: api.QuirksAddRemoveAlsoLocks |
 		api.QuirksAddRemoveAlsoInstalls |
-		api.QuirksLockAlsoInstalls,
+		api.QuirksLockAlsoInstalls |
+		api.QuirkRemoveNeedsLockfile,
 	GetPackageDir: func() string {
 		return "node_modules"
 	},

--- a/internal/cli/cmds.go
+++ b/internal/cli/cmds.go
@@ -578,7 +578,10 @@ func runShowSpecfile(language string) {
 
 // runShowLockfile implements 'upm show-lockfile'.
 func runShowLockfile(language string) {
-	fmt.Println(backends.GetBackend(context.Background(), language).Lockfile)
+	b := backends.GetBackend(context.Background(), language)
+	if b.Lockfile != "" {
+		fmt.Println(b.Lockfile)
+	}
 }
 
 // runShowPackageDir implements 'upm show-package-dir'.

--- a/internal/cli/cmds.go
+++ b/internal/cli/cmds.go
@@ -362,10 +362,10 @@ func runRemove(language string, args []string, upgrade bool,
 
 	// Map from normalized package names to original package
 	// names.
-	normPkgs := map[api.PkgName]api.PkgName{}
+	normPkgs := map[api.PkgName]string{}
 	for _, arg := range args {
-		name := api.PkgName(arg)
-		norm := b.NormalizePackageName(name)
+		name := arg
+		norm := b.NormalizePackageName(api.PkgName(arg))
 		if normSpecfilePkgs[norm] {
 			normPkgs[norm] = name
 		}
@@ -377,7 +377,7 @@ func runRemove(language string, args []string, upgrade bool,
 
 	if len(normPkgs) >= 1 {
 		pkgs := map[api.PkgName]bool{}
-		for _, name := range normPkgs {
+		for name := range normPkgs {
 			pkgs[name] = true
 		}
 		b.Remove(ctx, pkgs)

--- a/test-suite/Add_test.go
+++ b/test-suite/Add_test.go
@@ -41,7 +41,7 @@ func doAdd(bt testUtils.BackendT, pkgs ...string) {
 	for _, tmpl := range standardTemplates {
 		template := bt.Backend.Name + "/" + tmpl + "/"
 		bt.Subtest(tmpl, func(bt testUtils.BackendT) {
-			if tmpl != "no-deps" {
+			if tmpl != "no-deps" && bt.Backend.QuirksIsReproducible() {
 				bt.Subtest("locked", func(bt testUtils.BackendT) {
 					bt.Subtest("each", func(bt testUtils.BackendT) {
 						bt.AddTestFile(template+bt.Backend.Specfile, bt.Backend.Specfile)

--- a/test-suite/Add_test.go
+++ b/test-suite/Add_test.go
@@ -40,12 +40,30 @@ func TestAdd(t *testing.T) {
 func doAdd(bt testUtils.BackendT, pkgs ...string) {
 	for _, tmpl := range standardTemplates {
 		template := bt.Backend.Name + "/" + tmpl + "/"
-		bt.Subtest(tmpl, func(bt testUtils.BackendT) {
-			if tmpl != "no-deps" && bt.Backend.QuirksIsReproducible() {
-				bt.Subtest("locked", func(bt testUtils.BackendT) {
+
+		if tmpl != "no-deps" {
+			bt.Subtest(tmpl, func(bt testUtils.BackendT) {
+				if bt.Backend.QuirksIsReproducible() {
+					bt.Subtest("locked", func(bt testUtils.BackendT) {
+						bt.Subtest("each", func(bt testUtils.BackendT) {
+							bt.AddTestFile(template+bt.Backend.Specfile, bt.Backend.Specfile)
+							bt.AddTestFile(template+bt.Backend.Lockfile, bt.Backend.Lockfile)
+							for _, pkg := range pkgs {
+								bt.UpmAdd(pkg)
+							}
+						})
+
+						bt.Subtest("all", func(bt testUtils.BackendT) {
+							bt.AddTestFile(template+bt.Backend.Specfile, bt.Backend.Specfile)
+							bt.AddTestFile(template+bt.Backend.Lockfile, bt.Backend.Lockfile)
+							bt.UpmAdd(pkgs...)
+						})
+					})
+				}
+
+				bt.Subtest("unlocked", func(bt testUtils.BackendT) {
 					bt.Subtest("each", func(bt testUtils.BackendT) {
 						bt.AddTestFile(template+bt.Backend.Specfile, bt.Backend.Specfile)
-						bt.AddTestFile(template+bt.Backend.Lockfile, bt.Backend.Lockfile)
 						for _, pkg := range pkgs {
 							bt.UpmAdd(pkg)
 						}
@@ -53,25 +71,10 @@ func doAdd(bt testUtils.BackendT, pkgs ...string) {
 
 					bt.Subtest("all", func(bt testUtils.BackendT) {
 						bt.AddTestFile(template+bt.Backend.Specfile, bt.Backend.Specfile)
-						bt.AddTestFile(template+bt.Backend.Lockfile, bt.Backend.Lockfile)
 						bt.UpmAdd(pkgs...)
 					})
 				})
-			}
-
-			bt.Subtest("unlocked", func(bt testUtils.BackendT) {
-				bt.Subtest("each", func(bt testUtils.BackendT) {
-					bt.AddTestFile(template+bt.Backend.Specfile, bt.Backend.Specfile)
-					for _, pkg := range pkgs {
-						bt.UpmAdd(pkg)
-					}
-				})
-
-				bt.Subtest("all", func(bt testUtils.BackendT) {
-					bt.AddTestFile(template+bt.Backend.Specfile, bt.Backend.Specfile)
-					bt.UpmAdd(pkgs...)
-				})
 			})
-		})
+		}
 	}
 }

--- a/test-suite/Install_test.go
+++ b/test-suite/Install_test.go
@@ -32,7 +32,9 @@ func doInstall(bt testUtils.BackendT) {
 		template := bt.Backend.Name + "/" + tmpl + "/"
 		bt.Subtest(tmpl, func(bt testUtils.BackendT) {
 			bt.AddTestFile(template+bt.Backend.Specfile, bt.Backend.Specfile)
-			bt.AddTestFile(template+bt.Backend.Lockfile, bt.Backend.Lockfile)
+			if bt.Backend.QuirksIsReproducible() {
+				bt.AddTestFile(template+bt.Backend.Lockfile, bt.Backend.Lockfile)
+			}
 
 			bt.UpmInstall()
 

--- a/test-suite/Remove_test.go
+++ b/test-suite/Remove_test.go
@@ -49,21 +49,39 @@ func doRemove(bt testUtils.BackendT, templatesToPkgsToRemove map[string][]string
 
 		if tmpl != "no-deps" {
 			bt.Subtest(tmpl, func(bt testUtils.BackendT) {
-				bt.Subtest("locked", func(bt testUtils.BackendT) {
-					bt.Subtest("each", func(bt testUtils.BackendT) {
-						bt.AddTestFile(template+bt.Backend.Specfile, bt.Backend.Specfile)
-						bt.AddTestFile(template+bt.Backend.Lockfile, bt.Backend.Lockfile)
-						for _, pkg := range pkgsToRemove {
-							bt.UpmRemove(pkg)
-						}
-					})
+				if bt.Backend.QuirksIsReproducible() {
+					bt.Subtest("locked", func(bt testUtils.BackendT) {
+						bt.Subtest("each", func(bt testUtils.BackendT) {
+							bt.AddTestFile(template+bt.Backend.Specfile, bt.Backend.Specfile)
+							bt.AddTestFile(template+bt.Backend.Lockfile, bt.Backend.Lockfile)
+							for _, pkg := range pkgsToRemove {
+								bt.UpmRemove(pkg)
+							}
+						})
 
-					bt.Subtest("all", func(bt testUtils.BackendT) {
-						bt.AddTestFile(template+bt.Backend.Specfile, bt.Backend.Specfile)
-						bt.AddTestFile(template+bt.Backend.Lockfile, bt.Backend.Lockfile)
-						bt.UpmRemove(pkgsToRemove...)
+						bt.Subtest("all", func(bt testUtils.BackendT) {
+							bt.AddTestFile(template+bt.Backend.Specfile, bt.Backend.Specfile)
+							bt.AddTestFile(template+bt.Backend.Lockfile, bt.Backend.Lockfile)
+							bt.UpmRemove(pkgsToRemove...)
+						})
 					})
-				})
+				}
+
+				if ! bt.Backend.QuirkRemoveNeedsLockfile() {
+					bt.Subtest("unlocked", func(bt testUtils.BackendT) {
+						bt.Subtest("each", func(bt testUtils.BackendT) {
+							bt.AddTestFile(template+bt.Backend.Specfile, bt.Backend.Specfile)
+							for _, pkg := range pkgsToRemove {
+								bt.UpmRemove(pkg)
+							}
+						})
+
+						bt.Subtest("all", func(bt testUtils.BackendT) {
+							bt.AddTestFile(template+bt.Backend.Specfile, bt.Backend.Specfile)
+							bt.UpmRemove(pkgsToRemove...)
+						})
+					})
+				}
 			})
 		}
 	}

--- a/test-suite/WhichLanguage_test.go
+++ b/test-suite/WhichLanguage_test.go
@@ -24,11 +24,18 @@ func TestWhichLanguage(t *testing.T) {
 		template := bt.Backend.Name + "/one-dep/"
 
 		bt.Subtest(bt.Backend.Name, func(bt testUtils.BackendT) {
-			bt.Subtest("locked", func(bt testUtils.BackendT) {
-				bt.AddTestFile(template+bt.Backend.Specfile, bt.Backend.Specfile)
-				bt.AddTestFile(template+bt.Backend.Lockfile, bt.Backend.Lockfile)
-				bt.UpmWhichLanguage()
-			})
+			if bt.Backend.QuirksIsReproducible() {
+				bt.Subtest("locked", func(bt testUtils.BackendT) {
+					bt.AddTestFile(template+bt.Backend.Specfile, bt.Backend.Specfile)
+					bt.AddTestFile(template+bt.Backend.Lockfile, bt.Backend.Lockfile)
+					bt.UpmWhichLanguage()
+				})
+			} else {
+				bt.Subtest("no lockfile", func(bt testUtils.BackendT) {
+					bt.AddTestFile(template+bt.Backend.Specfile, bt.Backend.Specfile)
+					bt.UpmWhichLanguage()
+				})
+			}
 
 			if defaults[bt.Backend.Name] {
 				bt.Subtest("default", func(bt testUtils.BackendT) {

--- a/test-suite/utils/upm.go
+++ b/test-suite/utils/upm.go
@@ -279,9 +279,11 @@ func (bt *BackendT) UpmRemove(pkgs ...string) {
 	}
 
 	for _, pkg := range pkgs {
-		for _, dep := range afterLockDeps {
-			if dep.Name == pkg {
-				bt.Fail("expected %s not in lock file after remove", pkg)
+		if bt.Backend.QuirksIsReproducible() {
+			for _, dep := range afterLockDeps {
+				if dep.Name == pkg {
+					bt.Fail("expected %s not in lock file after remove", pkg)
+				}
 			}
 		}
 

--- a/test-suite/utils/upm.go
+++ b/test-suite/utils/upm.go
@@ -148,6 +148,17 @@ func (bt *BackendT) UpmInstall() {
 	}
 }
 
+func normalizePackageNames(bt *BackendT, pkgs []api.PkgInfo) []api.PkgInfo {
+	for idx, pkg := range pkgs {
+		out := (string)(bt.Backend.NormalizePackageName(api.PkgName(pkg.Name)))
+		if pkgs[idx].Name != out {
+			bt.t.Log("Inconsistently normalized package name in results: ", pkgs[idx].Name, "did not equal", out)
+		}
+		pkgs[idx].Name = out
+	}
+	return pkgs
+}
+
 func (bt *BackendT) UpmListLockFile() []api.PkgInfo {
 	out, err := bt.Exec(
 		"upm",
@@ -169,7 +180,7 @@ func (bt *BackendT) UpmListLockFile() []api.PkgInfo {
 		bt.Fail("failed to decode json: %v", err)
 	}
 
-	return results
+	return normalizePackageNames(bt, results)
 }
 
 func (bt *BackendT) UpmListSpecFile() []api.PkgInfo {
@@ -192,7 +203,7 @@ func (bt *BackendT) UpmListSpecFile() []api.PkgInfo {
 		bt.Fail("failed to decode json: %v", err)
 	}
 
-	return results
+	return normalizePackageNames(bt, results)
 }
 
 func (bt *BackendT) UpmLock() {

--- a/test-suite/utils/upm.go
+++ b/test-suite/utils/upm.go
@@ -32,7 +32,7 @@ func (bt *BackendT) UpmAdd(pkgs ...string) {
 		bt.Fail("expected more deps in lock file after add (before %d, after %d)", len(beforeLockDeps), len(afterLockDeps))
 	}
 	if len(beforeSpecDeps) >= len(afterSpecDeps) {
-		bt.Fail("expected more deps in lock file after add (before %d, after %d)", len(beforeLockDeps), len(afterLockDeps))
+		bt.Fail("expected more deps in lock file after add (before %d, after %d)", len(beforeSpecDeps), len(afterSpecDeps))
 	}
 
 	for _, pkg := range pkgs {


### PR DESCRIPTION
~Depends on #181, #182 [Minified diff](https://github.com/replit/upm/compare/5b1ff50...dstewart/permit-nonreproducible-backends-to-be-tested)~

- Relax some restrictions around how we do testing when the nonreproducible quirk is enabled on a backend