### PR TITLE
Follow-on to wrapped-test-... goals

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,8 +96,25 @@ else
 test-suite:
 	nix develop -c nix shell -c go test -run $(GO_TEST_RUN_OPTS) ./test-suite
 
+# I don't have a great name for these. The cases are as follows:
+#   make test-python3            # This runs inside nix develop and gates test suite
+#                                # execution on any backend starting with python3
+#   make unwrapped-test-python3  # This sets the requisite envvars to run the filtered
+#                                # test suite execution, but letting you run
+#                                # _outside of nix_, should you need a virtualenv or
+#                                # something special.
+#   make wrapped-test-python3    # This is the underlying command that powers the above
+#                                # two modes. It isn't very useful when run directly,
+#                                # since it doesn't know where upm or the PYPI_MAP_DB are.
 test-%:
 	nix develop -c nix shell -c make wrapped-$@
+
+unwrapped-test-%:
+	label="$@"; \
+	label="$${label#unwrapped-}"; \
+	PATH=$$PWD/cmd/upm/:"$$PATH" \
+	PYPI_MAP_DB=$$PWD/internal/backends/python/pypi_map.sqlite \
+			 make wrapped-$$label
 
 wrapped-test-%:
 	suite_prefix="$$(echo "$@" | cut -d- -f 3-)"; \


### PR DESCRIPTION
When developing locally, it's useful to be able to call tests as they are if you're already inside a nix shell, instead of spawning a subshell and waiting for it to build.

This necessarily implies `make upm` before the tests, as in
```
make upm unwrapped-test-...
```