### PR TITLE
Update Scoop installation in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,10 +89,9 @@ repository and install with `makepkg` using the PKGBUILD in
 
 ### Windows
 
-Available on [Scoop](https://scoop.sh/) in a [custom
-bucket](https://github.com/lukesampson/scoop/wiki/Buckets).
+Available on [Scoop](https://scoop.sh/) in the [main
+bucket](https://github.com/ScoopInstaller/Main/blob/master/bucket/upm.json).
 
-    $ scoop bucket add replit https://github.com/replit/scoop-bucket.git
     $ scoop install upm
 
 ### Snappy


### PR DESCRIPTION
Another attempt at #11 with modern CI configuration

upm has been added to the main bucket with https://github.com/ScoopInstaller/Main/commit/029935dd01dada7562f423bcc54e54fc9490bc50