### PR TITLE
Define PkgSet abstraction

### DIFF
--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -404,14 +404,31 @@ func AdaptLegacyGuess(oldGuess func(ctx context.Context) (map[PkgName]bool, bool
 	}
 }
 
+func (pkgs *PkgSet) NormalizePackageNames(normalizePkgName func(PkgName) PkgName) PkgSet {
+	res := NewPkgSet()
+	for pkg := range *pkgs {
+		res.AddOne(normalizePkgName(pkg))
+	}
+	return res
+}
+
 func (pkgs *PkgSet) AddOne(pkg PkgName) {
 	(*pkgs)[pkg] = true
 }
 
+func (pkgs *PkgSet) Remove(pkg PkgName) {
+	for name := range *pkgs {
+		if name == pkg {
+			delete(*pkgs, name)
+			break
+		}
+	}
+}
+
 func (pkgs *PkgSet) Pkgs() [][]PkgName {
 	var res [][]PkgName
-	for name := range *pkgs {
-		res = append(res, []PkgName{name})
+	for pkg := range *pkgs {
+		res = append(res, []PkgName{pkg})
 	}
 	return res
 }

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -328,7 +328,7 @@ type LanguageBackend struct {
 	// (which is now wrong).
 	//
 	// This field is mandatory.
-	Guess func(ctx context.Context) (map[PkgName]bool, bool)
+	Guess func(ctx context.Context) (PkgSet, bool)
 
 	// Installs system dependencies into replit.nix for supported
 	// languages.
@@ -384,4 +384,34 @@ func (b *LanguageBackend) Setup() {
 			return name
 		}
 	}
+}
+
+type PkgSet map[PkgName]bool
+
+func NewPkgSet() PkgSet {
+	adapted := (PkgSet)(make(map[PkgName]bool))
+	return adapted
+}
+
+func AdaptLegacyGuess(oldGuess func(ctx context.Context) (map[PkgName]bool, bool)) func(ctx context.Context) (PkgSet, bool) {
+	return func(ctx context.Context) (PkgSet, bool) {
+		res, err := oldGuess(ctx)
+		adapted := NewPkgSet()
+		for key := range res {
+			adapted.AddOne(key)
+		}
+		return adapted, err
+	}
+}
+
+func (pkgs *PkgSet) AddOne(pkg PkgName) {
+	(*pkgs)[pkg] = true
+}
+
+func (pkgs *PkgSet) Pkgs() [][]PkgName {
+	var res [][]PkgName
+	for name := range *pkgs {
+		res = append(res, []PkgName{name})
+	}
+	return res
 }

--- a/internal/backends/dart/dart.go
+++ b/internal/backends/dart/dart.go
@@ -327,6 +327,6 @@ var DartPubBackend = api.LanguageBackend{
 	ListSpecfile:                       dartListPubspecYaml,
 	ListLockfile:                       dartListPubspecLock,
 	GuessRegexps:                       nil,
-	Guess:                              dartGuess,
+	Guess:                              api.AdaptLegacyGuess(dartGuess),
 	InstallReplitNixSystemDependencies: nix.DefaultInstallReplitNixSystemDependencies,
 }

--- a/internal/backends/elisp/elisp.go
+++ b/internal/backends/elisp/elisp.go
@@ -197,7 +197,7 @@ var ElispBackend = api.LanguageBackend{
 	GuessRegexps: util.Regexps([]string{
 		`\(\s*require\s*'\s*([^)[:space:]]+)[^)]*\)`,
 	}),
-	Guess: func(ctx context.Context) (map[api.PkgName]bool, bool) {
+	Guess: api.AdaptLegacyGuess(func(ctx context.Context) (map[api.PkgName]bool, bool) {
 		//nolint:ineffassign,wastedassign,staticcheck
 		span, ctx := tracer.StartSpanFromContext(ctx, "elisp guess")
 		defer span.Finish()
@@ -260,6 +260,6 @@ var ElispBackend = api.LanguageBackend{
 			names[api.PkgName(match[1])] = true
 		}
 		return names, true
-	},
+	}),
 	InstallReplitNixSystemDependencies: nix.DefaultInstallReplitNixSystemDependencies,
 }

--- a/internal/backends/nodejs/nodejs.go
+++ b/internal/backends/nodejs/nodejs.go
@@ -461,7 +461,7 @@ var NodejsYarnBackend = api.LanguageBackend{
 	},
 	// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import
 	GuessRegexps:                       nodejsGuessRegexps,
-	Guess:                              nodejsGuess,
+	Guess:                              api.AdaptLegacyGuess(nodejsGuess),
 	InstallReplitNixSystemDependencies: nix.DefaultInstallReplitNixSystemDependencies,
 }
 
@@ -555,7 +555,7 @@ var NodejsPNPMBackend = api.LanguageBackend{
 	},
 	// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import
 	GuessRegexps:                       nodejsGuessRegexps,
-	Guess:                              nodejsGuess,
+	Guess:                              api.AdaptLegacyGuess(nodejsGuess),
 	InstallReplitNixSystemDependencies: nix.DefaultInstallReplitNixSystemDependencies,
 }
 
@@ -638,7 +638,7 @@ var NodejsNPMBackend = api.LanguageBackend{
 	},
 	// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import
 	GuessRegexps:                       nodejsGuessRegexps,
-	Guess:                              nodejsGuess,
+	Guess:                              api.AdaptLegacyGuess(nodejsGuess),
 	InstallReplitNixSystemDependencies: nix.DefaultInstallReplitNixSystemDependencies,
 }
 
@@ -717,6 +717,6 @@ var BunBackend = api.LanguageBackend{
 	},
 	// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import
 	GuessRegexps:                       nodejsGuessRegexps,
-	Guess:                              nodejsGuess,
+	Guess:                              api.AdaptLegacyGuess(nodejsGuess),
 	InstallReplitNixSystemDependencies: nix.DefaultInstallReplitNixSystemDependencies,
 }

--- a/internal/backends/php/php.go
+++ b/internal/backends/php/php.go
@@ -280,9 +280,9 @@ var PhpComposerBackend = api.LanguageBackend{
 	},
 	ListSpecfile: listSpecfile,
 	ListLockfile: listLockfile,
-	Guess: func(context.Context) (map[api.PkgName]bool, bool) {
+	Guess: api.AdaptLegacyGuess(func(context.Context) (map[api.PkgName]bool, bool) {
 		util.NotImplemented()
 		return nil, false
-	},
+	}),
 	InstallReplitNixSystemDependencies: nix.DefaultInstallReplitNixSystemDependencies,
 }

--- a/internal/backends/python/python.go
+++ b/internal/backends/python/python.go
@@ -298,7 +298,7 @@ func makePythonPoetryBackend(python string) api.LanguageBackend {
 			return pkgs
 		},
 		GuessRegexps: pythonGuessRegexps,
-		Guess:        func(ctx context.Context) (map[api.PkgName]bool, bool) { return guess(ctx, python) },
+		Guess:        api.AdaptLegacyGuess(func(ctx context.Context) (map[api.PkgName]bool, bool) { return guess(ctx, python) }),
 		InstallReplitNixSystemDependencies: func(ctx context.Context, pkgs []api.PkgName) {
 			//nolint:ineffassign,wastedassign,staticcheck
 			span, ctx := tracer.StartSpanFromContext(ctx, "python.InstallReplitNixSystemDependencies")
@@ -450,7 +450,7 @@ func makePythonPipBackend(python string) api.LanguageBackend {
 			return normalizedPkgs
 		},
 		GuessRegexps: pythonGuessRegexps,
-		Guess:        func(ctx context.Context) (map[api.PkgName]bool, bool) { return guess(ctx, python) },
+		Guess:        api.AdaptLegacyGuess(func(ctx context.Context) (map[api.PkgName]bool, bool) { return guess(ctx, python) }),
 		InstallReplitNixSystemDependencies: func(ctx context.Context, pkgs []api.PkgName) {
 			//nolint:ineffassign,wastedassign,staticcheck
 			span, ctx := tracer.StartSpanFromContext(ctx, "python.InstallReplitNixSystemDependencies")

--- a/internal/backends/python/python.go
+++ b/internal/backends/python/python.go
@@ -298,7 +298,7 @@ func makePythonPoetryBackend(python string) api.LanguageBackend {
 			return pkgs
 		},
 		GuessRegexps: pythonGuessRegexps,
-		Guess:        api.AdaptLegacyGuess(func(ctx context.Context) (map[api.PkgName]bool, bool) { return guess(ctx, python) }),
+		Guess:        func(ctx context.Context) (api.PkgSet, bool) { return guess(ctx, python) },
 		InstallReplitNixSystemDependencies: func(ctx context.Context, pkgs []api.PkgName) {
 			//nolint:ineffassign,wastedassign,staticcheck
 			span, ctx := tracer.StartSpanFromContext(ctx, "python.InstallReplitNixSystemDependencies")
@@ -450,7 +450,7 @@ func makePythonPipBackend(python string) api.LanguageBackend {
 			return normalizedPkgs
 		},
 		GuessRegexps: pythonGuessRegexps,
-		Guess:        api.AdaptLegacyGuess(func(ctx context.Context) (map[api.PkgName]bool, bool) { return guess(ctx, python) }),
+		Guess:        func(ctx context.Context) (api.PkgSet, bool) { return guess(ctx, python) },
 		InstallReplitNixSystemDependencies: func(ctx context.Context, pkgs []api.PkgName) {
 			//nolint:ineffassign,wastedassign,staticcheck
 			span, ctx := tracer.StartSpanFromContext(ctx, "python.InstallReplitNixSystemDependencies")

--- a/internal/backends/rlang/rlang.go
+++ b/internal/backends/rlang/rlang.go
@@ -176,10 +176,10 @@ var RlangBackend = api.LanguageBackend{
 		return pkgs
 	},
 	//GuessRegexps: []*regexp.Regexp {regexp.MustCompile(`\brequire[ \t]*\(\s*([a-zA-Z_]\w*)\s*`)},
-	Guess: func(ctx context.Context) (map[api.PkgName]bool, bool) {
+	Guess: api.AdaptLegacyGuess(func(ctx context.Context) (map[api.PkgName]bool, bool) {
 		util.NotImplemented()
 
 		return nil, false
-	},
+	}),
 	InstallReplitNixSystemDependencies: nix.DefaultInstallReplitNixSystemDependencies,
 }

--- a/internal/backends/ruby/ruby.go
+++ b/internal/backends/ruby/ruby.go
@@ -255,7 +255,7 @@ var RubyBackend = api.LanguageBackend{
 	GuessRegexps: util.Regexps([]string{
 		`require\s*['"]([^'"]+)['"]`,
 	}),
-	Guess: func(ctx context.Context) (map[api.PkgName]bool, bool) {
+	Guess: api.AdaptLegacyGuess(func(ctx context.Context) (map[api.PkgName]bool, bool) {
 		//nolint:ineffassign,wastedassign,staticcheck
 		span, ctx := tracer.StartSpanFromContext(ctx, "guess-gems.rb")
 		defer span.Finish()
@@ -267,6 +267,6 @@ var RubyBackend = api.LanguageBackend{
 			util.Die("ruby: %s", err)
 		}
 		return results, true
-	},
+	}),
 	InstallReplitNixSystemDependencies: nix.DefaultInstallReplitNixSystemDependencies,
 }

--- a/internal/backends/rust/rust.go
+++ b/internal/backends/rust/rust.go
@@ -272,9 +272,9 @@ var RustBackend = api.LanguageBackend{
 	},
 	ListSpecfile: listSpecfile,
 	ListLockfile: listLockfile,
-	Guess: func(ctx context.Context) (map[api.PkgName]bool, bool) {
+	Guess: api.AdaptLegacyGuess(func(ctx context.Context) (map[api.PkgName]bool, bool) {
 		util.NotImplemented()
 		return nil, false
-	},
+	}),
 	InstallReplitNixSystemDependencies: nix.DefaultInstallReplitNixSystemDependencies,
 }

--- a/internal/cli/cmds.go
+++ b/internal/cli/cmds.go
@@ -287,17 +287,6 @@ func runAdd(
 	if guess {
 		guessed := store.GuessWithCache(ctx, b, forceGuess)
 
-		// Map from normalized package names to original
-		// names.
-		guessedNorm := map[api.PkgName]api.PkgName{}
-		for name := range guessed {
-			guessedNorm[b.NormalizePackageName(name)] = name
-		}
-
-		for _, pkg := range ignoredPackages {
-			delete(guessedNorm, b.NormalizePackageName(api.PkgName(pkg)))
-		}
-
 		for name := range guessed {
 			if _, ok := normPkgs[b.NormalizePackageName(name)]; !ok {
 				normPkgs[b.NormalizePackageName(name)] = pkgNameAndSpec{

--- a/internal/cli/cmds.go
+++ b/internal/cli/cmds.go
@@ -540,18 +540,20 @@ func runGuess(
 	b := backends.GetBackend(ctx, language)
 	guessed := store.GuessWithCache(ctx, b, forceGuess)
 
-	// Map from normalized to original names.
-	normPkgs := map[api.PkgName]api.PkgName{}
-	for _, pkgs := range guessed.Pkgs() {
-		normPkgs[b.NormalizePackageName(pkgs[0])] = pkgs[0]
-	}
+	guessed = guessed.NormalizePackageNames(b.NormalizePackageName)
 
 	if !all {
 		if util.Exists(b.Specfile) {
 			for name := range b.ListSpecfile() {
-				delete(normPkgs, b.NormalizePackageName(name))
+				guessed.Remove(b.NormalizePackageName(name))
 			}
 		}
+	}
+
+	// Map from normalized to original names.
+	normPkgs := map[api.PkgName]api.PkgName{}
+	for _, pkgs := range guessed.Pkgs() {
+		normPkgs[b.NormalizePackageName(pkgs[0])] = pkgs[0]
 	}
 
 	for _, pkg := range ignoredPackages {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -148,7 +148,7 @@ func HasLockfileChanged(b api.LanguageBackend) bool {
 // backend does specify b.GuessRegexps, then the return value of this
 // function is cached.) If forceGuess is true, then write to but do
 // not read from the cache.
-func GuessWithCache(ctx context.Context, b api.LanguageBackend, forceGuess bool) map[api.PkgName]bool {
+func GuessWithCache(ctx context.Context, b api.LanguageBackend, forceGuess bool) api.PkgSet {
 	span, ctx := tracer.StartSpanFromContext(ctx, "GuessWithCache")
 	defer span.Finish()
 	readMaybe()
@@ -163,7 +163,7 @@ func GuessWithCache(ctx context.Context, b api.LanguageBackend, forceGuess bool)
 		cache.GuessedImportsHash = new
 	}
 	if forceGuess || new != old {
-		var pkgs map[api.PkgName]bool
+		pkgs := api.NewPkgSet()
 		success := true
 		if new != "" {
 			pkgs, success = b.Guess(ctx)
@@ -174,7 +174,6 @@ func GuessWithCache(ctx context.Context, b api.LanguageBackend, forceGuess bool)
 			// case we shouldn't have any packages
 			// returned by the bare imports search. Might
 			// as well just skip the search, right?
-			pkgs = map[api.PkgName]bool{}
 		}
 		if !success {
 			// If bare imports search is not successful,
@@ -200,9 +199,9 @@ func GuessWithCache(ctx context.Context, b api.LanguageBackend, forceGuess bool)
 		}
 		return pkgs
 	} else {
-		pkgs := map[api.PkgName]bool{}
+		pkgs := api.NewPkgSet()
 		for _, name := range cache.GuessedImports {
-			pkgs[api.PkgName(name)] = true
+			pkgs.AddOne(api.PkgName(name))
 		}
 		return pkgs
 	}


### PR DESCRIPTION
RFC on the direction of this changeset.

The motivation here is to insulate the different backends from incidental changes to the guess data model.

`map[string]bool` needs to become `map[string][]api.PkgName` in order to permit multiple packages to satisfy the same `import`, in languages that permit package collisions (Python, in this case. Maybe others later.)

Second PR incoming, for more context.