### PR TITLE
Ranked packages for python guess

### DIFF
--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -328,7 +328,7 @@ type LanguageBackend struct {
 	// (which is now wrong).
 	//
 	// This field is mandatory.
-	Guess func(ctx context.Context) (map[PkgName]bool, bool)
+	Guess func(ctx context.Context) (map[string][]PkgName, bool)
 
 	// Installs system dependencies into replit.nix for supported
 	// languages.

--- a/internal/backends/dart/dart.go
+++ b/internal/backends/dart/dart.go
@@ -293,7 +293,7 @@ func dartRemove(ctx context.Context, pkgs map[api.PkgName]bool) {
 }
 
 // dartGuess stub.
-func dartGuess(context.Context) (map[api.PkgName]bool, bool) {
+func dartGuess(context.Context) (map[string][]api.PkgName, bool) {
 	util.Die("Guess not implemented!")
 
 	return nil, false

--- a/internal/backends/nodejs/grab.go
+++ b/internal/backends/nodejs/grab.go
@@ -57,7 +57,7 @@ var internalModules = []string{
 }
 
 // nodejsGuess implements Guess for nodejs-yarn, nodejs-pnpm and nodejs-npm.
-func nodejsGuess(ctx context.Context) (map[api.PkgName]bool, bool) {
+func nodejsGuess(ctx context.Context) (map[string][]api.PkgName, bool) {
 	span, ctx := tracer.StartSpanFromContext(ctx, "nodejsGuess")
 	defer span.Finish()
 	cwd, err := os.Getwd()
@@ -122,18 +122,18 @@ func findImports(ctx context.Context, dir string) (map[string]bool, error) {
 	return foundImportPaths, nil
 }
 
-func filterImports(ctx context.Context, foundPaths map[string]bool) map[api.PkgName]bool {
+func filterImports(ctx context.Context, foundPaths map[string]bool) map[string][]api.PkgName {
 	//nolint:ineffassign,wastedassign,staticcheck
 	span, ctx := tracer.StartSpanFromContext(ctx, "nodejs.grab.filterImports")
 	defer span.Finish()
-	pkgs := map[api.PkgName]bool{}
+	pkgs := map[string][]api.PkgName{}
 
 	for mod := range foundPaths {
 		if mod == "" {
 			continue
 		}
 
-		if pkgs[api.PkgName(mod)] {
+		if _, ok := pkgs[mod]; ok {
 			continue
 		}
 
@@ -195,7 +195,7 @@ func filterImports(ctx context.Context, foundPaths map[string]bool) map[api.PkgN
 			}
 		}
 
-		pkgs[api.PkgName(mod)] = true
+		pkgs[mod] = []api.PkgName{api.PkgName(mod)}
 	}
 
 	return pkgs

--- a/internal/backends/nodejs/nodejs_test.go
+++ b/internal/backends/nodejs/nodejs_test.go
@@ -12,7 +12,7 @@ type TestCase struct {
 	scenario    string
 	backend     api.LanguageBackend
 	fileContent string
-	expected    map[api.PkgName]bool
+	expected    map[string]bool
 }
 
 func TestNodejsYarnBackend_Guess(t *testing.T) {
@@ -25,7 +25,7 @@ func TestNodejsYarnBackend_Guess(t *testing.T) {
 
 			export const App = () => null;
 		`,
-			expected: map[api.PkgName]bool{
+			expected: map[string]bool{
 				"react": true,
 			},
 		},
@@ -35,7 +35,7 @@ func TestNodejsYarnBackend_Guess(t *testing.T) {
 			fileContent: `
 			const request = require('request');
 		`,
-			expected: map[api.PkgName]bool{
+			expected: map[string]bool{
 				"request": true,
 			},
 		},
@@ -45,7 +45,7 @@ func TestNodejsYarnBackend_Guess(t *testing.T) {
 			fileContent: `
 			const http = require('http');
 		`,
-			expected: map[api.PkgName]bool{},
+			expected: map[string]bool{},
 		},
 		{
 			scenario: "Ignore internal submodules imports",
@@ -53,7 +53,7 @@ func TestNodejsYarnBackend_Guess(t *testing.T) {
 			fileContent: `
 			const dns = require('dns/promises');
 		`,
-			expected: map[api.PkgName]bool{},
+			expected: map[string]bool{},
 		},
 		{
 			scenario: "Returns both requires and imports in mixed file",
@@ -62,7 +62,7 @@ func TestNodejsYarnBackend_Guess(t *testing.T) {
 			const request = require('request');
 			import yargs from 'yargs';
 		`,
-			expected: map[api.PkgName]bool{
+			expected: map[string]bool{
 				"request": true,
 				"yargs":   true,
 			},
@@ -76,7 +76,7 @@ func TestNodejsYarnBackend_Guess(t *testing.T) {
 
 			export const App = () => React.createElement(SomeComponent, {});
 		`,
-			expected: map[api.PkgName]bool{
+			expected: map[string]bool{
 				"react": true,
 			},
 		},
@@ -89,7 +89,7 @@ func TestNodejsYarnBackend_Guess(t *testing.T) {
 
 			export const App = () => React.createElement(SomeComponent, {});
 		`,
-			expected: map[api.PkgName]bool{},
+			expected: map[string]bool{},
 		},
 		{
 			scenario: "Will process packages in namespace",
@@ -100,7 +100,7 @@ func TestNodejsYarnBackend_Guess(t *testing.T) {
 
 			export const App = () => React.createElement(Button, { color: "primary" }, "Hello, World!");
 		`,
-			expected: map[api.PkgName]bool{
+			expected: map[string]bool{
 				"react":             true,
 				"@material-ui/core": true,
 			},
@@ -113,7 +113,7 @@ func TestNodejsYarnBackend_Guess(t *testing.T) {
 				require("node-fetch");
 			}
 		`,
-			expected: map[api.PkgName]bool{
+			expected: map[string]bool{
 				"node-fetch": true,
 			},
 		},
@@ -127,7 +127,7 @@ func TestNodejsYarnBackend_Guess(t *testing.T) {
 				require("node-fetch");
 			}
 		`,
-			expected: map[api.PkgName]bool{},
+			expected: map[string]bool{},
 		},
 		{
 			scenario: "dynamic import",
@@ -138,7 +138,7 @@ func TestNodejsYarnBackend_Guess(t *testing.T) {
 				import("node-fetch");
 			}
 		`,
-			expected: map[api.PkgName]bool{
+			expected: map[string]bool{
 				"node-fetch": true,
 			},
 		},
@@ -152,7 +152,7 @@ func TestNodejsYarnBackend_Guess(t *testing.T) {
 				import("node-fetch");
 			}
 		`,
-			expected: map[api.PkgName]bool{},
+			expected: map[string]bool{},
 		},
 	}
 
@@ -197,7 +197,7 @@ func verify(t *testing.T, tc TestCase, extension string) {
 	}
 
 	for key := range tc.expected {
-		if !result[key] {
+		if _, ok := result[key]; !ok {
 			t.Errorf("Key %s not found in result map", key)
 		}
 	}

--- a/internal/backends/php/php.go
+++ b/internal/backends/php/php.go
@@ -280,7 +280,7 @@ var PhpComposerBackend = api.LanguageBackend{
 	},
 	ListSpecfile: listSpecfile,
 	ListLockfile: listLockfile,
-	Guess: func(context.Context) (map[api.PkgName]bool, bool) {
+	Guess: func(context.Context) (map[string][]api.PkgName, bool) {
 		util.NotImplemented()
 		return nil, false
 	},

--- a/internal/backends/python/grab.go
+++ b/internal/backends/python/grab.go
@@ -304,7 +304,7 @@ func filterImports(ctx context.Context, foundPkgs map[string]bool) (map[string][
 		var overrides []string
 		var ok bool
 
-		modNameParts := strings.Split(fullModname, ".")
+		modNameParts := strings.Split(strings.ToLower(fullModname), ".")
 		for len(modNameParts) > 0 {
 			testModName := strings.Join(modNameParts, ".")
 

--- a/internal/backends/python/grab.go
+++ b/internal/backends/python/grab.go
@@ -315,7 +315,7 @@ func filterImports(ctx context.Context, foundPkgs map[string]bool) (map[string][
 			}
 
 			// test aliases
-			overrides, ok = moduleToPypiPackageAliases[testModName]
+			pkg, ok = moduleToPypiPackageAliases[testModName]
 			if ok {
 				break
 			}

--- a/internal/backends/python/grab.go
+++ b/internal/backends/python/grab.go
@@ -314,6 +314,12 @@ func filterImports(ctx context.Context, foundPkgs map[string]bool) (map[string][
 				break
 			}
 
+			// test aliases
+			overrides, ok = moduleToPypiPackageAliases[testModName]
+			if ok {
+				break
+			}
+
 			// test pypi
 			pkg, ok = pypiMap.ModuleToPackage(testModName)
 			if ok {

--- a/internal/backends/python/pypi_map.override.go
+++ b/internal/backends/python/pypi_map.override.go
@@ -18,5 +18,5 @@ var moduleToPypiPackageOverride = map[string][]string{
 	 */
 	"discord": {"discord.py"},
 	"bs4":     {"beautifulsoup4"},
-	"glm":     {"PyGLM"},
+	"glm":     {"PyGLM", "glm"},
 }

--- a/internal/backends/python/pypi_map.override.go
+++ b/internal/backends/python/pypi_map.override.go
@@ -3,20 +3,20 @@ package python
 /*
 Manual module -> package mapping overrides
 */
-var moduleToPypiPackageOverride = map[string]string{
-	"grpc_status":  "grpcio-status",       // 2nd most popular
-	"nvd3":         "python-nvd3",         // not popular enough 6th in popularity
-	"requirements": "requirements-parser", // popular rlbot depends on it, but doesn't supply requires_dist
-	"base62":       "pybase62",            // it was overridden by base-62 which wins due to name match but is less popular by far
-	"faiss":        "faiss-cpu",           // faiss is offered as precompiled wheels, faiss-cpu and faiss-gpu.
-	"graphics":     "graphics.py",         // this package is popular, but the module doesn't match the package name https://anh.cs.luc.edu/python/hands-on/3.1/handsonHtml/graphics.html#a-graphics-introduction
-	"replit.ai":    "replit-ai",           // Replit's AI package
+var moduleToPypiPackageOverride = map[string][]string{
+	"grpc_status":  {"grpcio-status"},       // 2nd most popular
+	"nvd3":         {"python-nvd3"},         // not popular enough 6th in popularity
+	"requirements": {"requirements-parser"}, // popular rlbot depends on it, but doesn't supply requires_dist
+	"base62":       {"pybase62"},            // it was overridden by base-62 which wins due to name match but is less popular by far
+	"faiss":        {"faiss-cpu"},           // faiss is offered as precompiled wheels, faiss-cpu and faiss-gpu.
+	"graphics":     {"graphics.py"},         // this package is popular, but the module doesn't match the package name https://anh.cs.luc.edu/python/hands-on/3.1/handsonHtml/graphics.html#a-graphics-introduction
+	"replit.ai":    {"replit-ai"},           // Replit's AI package
 	/* Proxy packages
 	 *
 	 * These are packages that provide helpful aliases, but otherwise provide no functionality.
 	 * We should prefer the real version.
 	 */
-	"discord": "discord.py",
-	"bs4":     "beautifulsoup4",
-	"glm":     "PyGLM",
+	"discord": {"discord.py"},
+	"bs4":     {"beautifulsoup4"},
+	"glm":     {"PyGLM"},
 }

--- a/internal/backends/python/pypi_map.override.go
+++ b/internal/backends/python/pypi_map.override.go
@@ -19,8 +19,8 @@ var moduleToPypiPackageOverride = map[string][]string{
  * These are packages that provide helpful aliases, but otherwise provide no functionality.
  * We should prefer the real version.
  */
-var moduleToPypiPackageAliases = map[string][]string{
-	"bs4":      {"beautifulsoup4"},
-	"discord":  {"discord.py"},
-	"psycopg2": {"psycopg2-binary"}, // psycopg2 is a source package, psycopg2-binary is the dist wheel
+var moduleToPypiPackageAliases = map[string]string{
+	"bs4":      "beautifulsoup4",
+	"discord":  "discord.py",
+	"psycopg2": "psycopg2-binary", // psycopg2 is a source package, psycopg2-binary is the dist wheel
 }

--- a/internal/backends/python/pypi_map.override.go
+++ b/internal/backends/python/pypi_map.override.go
@@ -11,12 +11,16 @@ var moduleToPypiPackageOverride = map[string][]string{
 	"faiss":        {"faiss-cpu"},           // faiss is offered as precompiled wheels, faiss-cpu and faiss-gpu.
 	"graphics":     {"graphics.py"},         // this package is popular, but the module doesn't match the package name https://anh.cs.luc.edu/python/hands-on/3.1/handsonHtml/graphics.html#a-graphics-introduction
 	"replit.ai":    {"replit-ai"},           // Replit's AI package
-	/* Proxy packages
-	 *
-	 * These are packages that provide helpful aliases, but otherwise provide no functionality.
-	 * We should prefer the real version.
-	 */
-	"discord": {"discord.py"},
-	"bs4":     {"beautifulsoup4"},
-	"glm":     {"PyGLM", "glm"},
+	"glm":          {"PyGLM", "glm"},        // Both of these packages are valid, but PyGLM is a library, glm is an executable.
+}
+
+/* Proxy packages
+ *
+ * These are packages that provide helpful aliases, but otherwise provide no functionality.
+ * We should prefer the real version.
+ */
+var moduleToPypiPackageAliases = map[string][]string{
+	"bs4":      {"beautifulsoup4"},
+	"discord":  {"discord.py"},
+	"psycopg2": {"psycopg2-binary"}, // psycopg2 is a source package, psycopg2-binary is the dist wheel
 }

--- a/internal/backends/python/python.go
+++ b/internal/backends/python/python.go
@@ -178,6 +178,11 @@ func add(ctx context.Context, pkgs map[api.PkgName]api.PkgSpec, projectName stri
 	cmd := []string{"poetry", "add"}
 	for name, spec := range pkgs {
 		name := string(name)
+		if found, ok := moduleToPypiPackageAliases[name]; ok {
+			delete(pkgs, api.PkgName(name))
+			name = found[0]
+			pkgs[api.PkgName(name)] = api.PkgSpec(spec)
+		}
 		spec := string(spec)
 
 		// NB: this doesn't work if spec has
@@ -375,6 +380,11 @@ func makePythonPipBackend(python string) api.LanguageBackend {
 			for name, spec := range pkgs {
 				name := string(name)
 				spec := string(spec)
+				if found, ok := moduleToPypiPackageAliases[name]; ok {
+					delete(pkgs, api.PkgName(name))
+					name = found[0]
+					pkgs[api.PkgName(name)] = api.PkgSpec(spec)
+				}
 
 				cmd = append(cmd, name+spec)
 			}

--- a/internal/backends/python/python.go
+++ b/internal/backends/python/python.go
@@ -180,7 +180,7 @@ func add(ctx context.Context, pkgs map[api.PkgName]api.PkgSpec, projectName stri
 		name := string(name)
 		if found, ok := moduleToPypiPackageAliases[name]; ok {
 			delete(pkgs, api.PkgName(name))
-			name = found[0]
+			name = found
 			pkgs[api.PkgName(name)] = api.PkgSpec(spec)
 		}
 		spec := string(spec)
@@ -382,7 +382,7 @@ func makePythonPipBackend(python string) api.LanguageBackend {
 				spec := string(spec)
 				if found, ok := moduleToPypiPackageAliases[name]; ok {
 					delete(pkgs, api.PkgName(name))
-					name = found[0]
+					name = found
 					pkgs[api.PkgName(name)] = api.PkgSpec(spec)
 				}
 

--- a/internal/backends/python/python.go
+++ b/internal/backends/python/python.go
@@ -196,7 +196,7 @@ func add(ctx context.Context, pkgs map[api.PkgName]api.PkgSpec, projectName stri
 
 func searchPypi(query string) []api.PkgInfo {
 	if renamed, found := moduleToPypiPackageOverride[query]; found {
-		query = renamed
+		query = renamed[0]
 	}
 	results, err := SearchPypi(query)
 	if err != nil {
@@ -298,7 +298,7 @@ func makePythonPoetryBackend(python string) api.LanguageBackend {
 			return pkgs
 		},
 		GuessRegexps: pythonGuessRegexps,
-		Guess:        func(ctx context.Context) (map[api.PkgName]bool, bool) { return guess(ctx, python) },
+		Guess:        func(ctx context.Context) (map[string][]api.PkgName, bool) { return guess(ctx, python) },
 		InstallReplitNixSystemDependencies: func(ctx context.Context, pkgs []api.PkgName) {
 			//nolint:ineffassign,wastedassign,staticcheck
 			span, ctx := tracer.StartSpanFromContext(ctx, "python.InstallReplitNixSystemDependencies")
@@ -459,7 +459,7 @@ func makePythonPipBackend(python string) api.LanguageBackend {
 			return pkgs
 		},
 		GuessRegexps: pythonGuessRegexps,
-		Guess:        func(ctx context.Context) (map[api.PkgName]bool, bool) { return guess(ctx, python) },
+		Guess:        func(ctx context.Context) (map[string][]api.PkgName, bool) { return guess(ctx, python) },
 		InstallReplitNixSystemDependencies: func(ctx context.Context, pkgs []api.PkgName) {
 			//nolint:ineffassign,wastedassign,staticcheck
 			span, ctx := tracer.StartSpanFromContext(ctx, "python.InstallReplitNixSystemDependencies")

--- a/internal/backends/rlang/rlang.go
+++ b/internal/backends/rlang/rlang.go
@@ -176,7 +176,7 @@ var RlangBackend = api.LanguageBackend{
 		return pkgs
 	},
 	//GuessRegexps: []*regexp.Regexp {regexp.MustCompile(`\brequire[ \t]*\(\s*([a-zA-Z_]\w*)\s*`)},
-	Guess: func(ctx context.Context) (map[api.PkgName]bool, bool) {
+	Guess: func(ctx context.Context) (map[string][]api.PkgName, bool) {
 		util.NotImplemented()
 
 		return nil, false

--- a/internal/backends/ruby/ruby.go
+++ b/internal/backends/ruby/ruby.go
@@ -255,14 +255,14 @@ var RubyBackend = api.LanguageBackend{
 	GuessRegexps: util.Regexps([]string{
 		`require\s*['"]([^'"]+)['"]`,
 	}),
-	Guess: func(ctx context.Context) (map[api.PkgName]bool, bool) {
+	Guess: func(ctx context.Context) (map[string][]api.PkgName, bool) {
 		//nolint:ineffassign,wastedassign,staticcheck
 		span, ctx := tracer.StartSpanFromContext(ctx, "guess-gems.rb")
 		defer span.Finish()
 		guessedGems := util.GetCmdOutput([]string{
 			"ruby", "-e", util.GetResource("/ruby/guess-gems.rb"),
 		})
-		results := map[api.PkgName]bool{}
+		results := map[string][]api.PkgName{}
 		if err := json.Unmarshal(guessedGems, &results); err != nil {
 			util.Die("ruby: %s", err)
 		}

--- a/internal/backends/rust/rust.go
+++ b/internal/backends/rust/rust.go
@@ -272,7 +272,7 @@ var RustBackend = api.LanguageBackend{
 	},
 	ListSpecfile: listSpecfile,
 	ListLockfile: listLockfile,
-	Guess: func(ctx context.Context) (map[api.PkgName]bool, bool) {
+	Guess: func(ctx context.Context) (map[string][]api.PkgName, bool) {
 		util.NotImplemented()
 		return nil, false
 	},

--- a/internal/cli/cmds.go
+++ b/internal/cli/cmds.go
@@ -357,6 +357,7 @@ func runAdd(
 		maybeInstall(ctx, b, forceInstall)
 	}
 
+	store.Read(ctx, b)
 	store.ClearGuesses(ctx, b)
 	store.UpdateFileHashes(ctx, b)
 	store.Write(ctx)
@@ -416,6 +417,7 @@ func runRemove(language string, args []string, upgrade bool,
 		maybeInstall(ctx, b, forceInstall)
 	}
 
+	store.Read(ctx, b)
 	store.ClearGuesses(ctx, b)
 	store.UpdateFileHashes(ctx, b)
 	store.Write(ctx)
@@ -437,6 +439,7 @@ func runLock(language string, upgrade bool, forceLock bool, forceInstall bool) {
 		maybeInstall(ctx, b, forceInstall)
 	}
 
+	store.Read(ctx, b)
 	store.UpdateFileHashes(ctx, b)
 	store.Write(ctx)
 }
@@ -449,6 +452,7 @@ func runInstall(language string, force bool) {
 
 	maybeInstall(ctx, b, force)
 
+	store.Read(ctx, b)
 	store.UpdateFileHashes(ctx, b)
 	store.Write(ctx)
 }

--- a/internal/cli/cmds.go
+++ b/internal/cli/cmds.go
@@ -287,7 +287,8 @@ func runAdd(
 	if guess {
 		guessed := store.GuessWithCache(ctx, b, forceGuess)
 
-		for name := range guessed {
+		for _, guesses := range guessed {
+			name := guesses[0]
 			if _, ok := normPkgs[b.NormalizePackageName(name)]; !ok {
 				normPkgs[b.NormalizePackageName(name)] = pkgNameAndSpec{
 					name: name,
@@ -535,8 +536,8 @@ func runGuess(
 
 	// Map from normalized to original names.
 	normPkgs := map[api.PkgName]api.PkgName{}
-	for pkg := range pkgs {
-		normPkgs[b.NormalizePackageName(pkg)] = pkg
+	for _, guesses := range pkgs {
+		normPkgs[b.NormalizePackageName(guesses[0])] = guesses[0]
 	}
 
 	if !all {

--- a/internal/cli/cmds.go
+++ b/internal/cli/cmds.go
@@ -357,6 +357,7 @@ func runAdd(
 		maybeInstall(ctx, b, forceInstall)
 	}
 
+	store.ClearGuesses(ctx, b)
 	store.UpdateFileHashes(ctx, b)
 	store.Write(ctx)
 }
@@ -415,6 +416,7 @@ func runRemove(language string, args []string, upgrade bool,
 		maybeInstall(ctx, b, forceInstall)
 	}
 
+	store.ClearGuesses(ctx, b)
 	store.UpdateFileHashes(ctx, b)
 	store.Write(ctx)
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -208,6 +208,16 @@ func GuessWithCache(ctx context.Context, b api.LanguageBackend, forceGuess bool)
 	}
 }
 
+func ClearGuesses(ctx context.Context, b api.LanguageBackend) {
+	span, ctx := tracer.StartSpanFromContext(ctx, "ClearGuesses")
+	defer span.Finish()
+
+	cache := getLanguageCache(b.Name, b.Alias)
+
+	cache.GuessedImports = nil
+	cache.GuessedImportsHash = ""
+}
+
 // UpdateFileHashes caches the current states of the specfile and
 // lockfile. Neither file need exist.
 func UpdateFileHashes(ctx context.Context, b api.LanguageBackend) {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -209,6 +209,7 @@ func GuessWithCache(ctx context.Context, b api.LanguageBackend, forceGuess bool)
 }
 
 func ClearGuesses(ctx context.Context, b api.LanguageBackend) {
+	//nolint:ineffassign,wastedassign,staticcheck
 	span, ctx := tracer.StartSpanFromContext(ctx, "ClearGuesses")
 	defer span.Finish()
 
@@ -218,14 +219,20 @@ func ClearGuesses(ctx context.Context, b api.LanguageBackend) {
 	cache.GuessedImportsHash = ""
 }
 
+func Read(ctx context.Context, b api.LanguageBackend) {
+	//nolint:ineffassign,wastedassign,staticcheck
+	span, ctx := tracer.StartSpanFromContext(ctx, "store.Read")
+	defer span.Finish()
+	readMaybe()
+	initLanguage(b.Name, b.Alias)
+}
+
 // UpdateFileHashes caches the current states of the specfile and
 // lockfile. Neither file need exist.
 func UpdateFileHashes(ctx context.Context, b api.LanguageBackend) {
 	//nolint:ineffassign,wastedassign,staticcheck
 	span, ctx := tracer.StartSpanFromContext(ctx, "store.UpdateFileHashes")
 	defer span.Finish()
-	readMaybe()
-	initLanguage(b.Name, b.Alias)
 	cache := getLanguageCache(b.Name, b.Alias)
 	cache.SpecfileHash = hashFile(b.Specfile)
 	cache.LockfileHash = hashFile(b.Lockfile)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -148,7 +148,7 @@ func HasLockfileChanged(b api.LanguageBackend) bool {
 // backend does specify b.GuessRegexps, then the return value of this
 // function is cached.) If forceGuess is true, then write to but do
 // not read from the cache.
-func GuessWithCache(ctx context.Context, b api.LanguageBackend, forceGuess bool) map[api.PkgName]bool {
+func GuessWithCache(ctx context.Context, b api.LanguageBackend, forceGuess bool) map[string][]api.PkgName {
 	span, ctx := tracer.StartSpanFromContext(ctx, "GuessWithCache")
 	defer span.Finish()
 	readMaybe()
@@ -163,7 +163,7 @@ func GuessWithCache(ctx context.Context, b api.LanguageBackend, forceGuess bool)
 		cache.GuessedImportsHash = new
 	}
 	if forceGuess || new != old {
-		var pkgs map[api.PkgName]bool
+		var pkgs map[string][]api.PkgName
 		success := true
 		if new != "" {
 			pkgs, success = b.Guess(ctx)
@@ -174,7 +174,7 @@ func GuessWithCache(ctx context.Context, b api.LanguageBackend, forceGuess bool)
 			// case we shouldn't have any packages
 			// returned by the bare imports search. Might
 			// as well just skip the search, right?
-			pkgs = map[api.PkgName]bool{}
+			pkgs = map[string][]api.PkgName{}
 		}
 		if !success {
 			// If bare imports search is not successful,
@@ -200,9 +200,9 @@ func GuessWithCache(ctx context.Context, b api.LanguageBackend, forceGuess bool)
 		}
 		return pkgs
 	} else {
-		pkgs := map[api.PkgName]bool{}
+		pkgs := map[string][]api.PkgName{}
 		for _, name := range cache.GuessedImports {
-			pkgs[api.PkgName(name)] = true
+			pkgs[name] = []api.PkgName{api.PkgName(name)}
 		}
 		return pkgs
 	}

--- a/resources/ruby/guess-gems.rb
+++ b/resources/ruby/guess-gems.rb
@@ -47,7 +47,7 @@ def process_require(req_str, guesses)
 
   gem = $allowed_gems[req_str]
   if gem
-    guesses[gem] = true
+    guesses[gem] = [gem]
   end
 end
 

--- a/test-suite/templates/guess/py/basic
+++ b/test-suite/templates/guess/py/basic
@@ -2,3 +2,4 @@ from django.shortcuts import render
 # this is an arbitrary comment
 from flask import Flask
 import replit.ai
+import glm

--- a/test-suite/templates/guess/py/basic.expect
+++ b/test-suite/templates/guess/py/basic.expect
@@ -1,3 +1,4 @@
 django
 flask
 replit-ai
+pyglm


### PR DESCRIPTION
Initial work towards #15 

- Converting `Guess` over to an import statement mapping to multiple packages that can provide that import
- If any package in the package array is installed, the entire array is removed
- After filtering, we pick the first package in every array and offer those as the response from `guess` 

Follow-on work to this as follows:
1) Augment the process that writes `internal/nix/python_map.json` to also include information about which package roots (the shallowest module in a package with more than one child, to start. There may be some utility in indexing what classes are available as well, but that'll come in the future)
2) Alter UPM to build a bespoke index by walking the `$PYTHONPATH` to exclude packages from `guess` that already supply necessary imports.