### PR TITLE
Avoid panicking on CLI error

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -341,6 +341,8 @@ func DoCLI() {
 	util.ChdirToUPM()
 	err := rootCmd.Execute()
 	if err != nil {
-		panic(err)
+		// We don't need to log anything here,
+		// cobra.Command does its own error logging.
+		os.Exit(1)
 	}
 }


### PR DESCRIPTION
This isn't great:

```
$ upm init
Error: unknown command "init" for "upm"

Did you mean this?
        info

Run 'upm --help' for usage.
panic: unknown command "init" for "upm"

Did you mean this?
        info


goroutine 1 [running]:
github.com/replit/upm/internal/cli.DoCLI()
        .../upm/internal/cli/cli.go:344 +0x1888
main.main()
        .../upm/cmd/upm/main.go:10 +0x1c
```

Since `cobra` already does [its own error logging](https://github.com/spf13/cobra/blob/v1.8.0/command.go#L1115-L1135), we can probably just exit 1 and call it a day.