### PR TITLE
Overeager pip normalization

### DIFF
--- a/internal/backends/python/python.go
+++ b/internal/backends/python/python.go
@@ -444,7 +444,9 @@ func makePythonPipBackend(python string) api.LanguageBackend {
 				normalizedPkgs[normalizePackageName(name)] = spec
 			}
 
-			// Stash the seen flags into a module global
+			// Stash the seen flags into a module global.
+			// This isn't great, but the expectation is that ListSpecfile
+			// is called before we run `Add`.
 			pipFlags = flags
 
 			return normalizedPkgs

--- a/internal/backends/python/python.go
+++ b/internal/backends/python/python.go
@@ -443,14 +443,9 @@ func makePythonPipBackend(python string) api.LanguageBackend {
 			util.RunCmd([]string{"pip", "install", "-r", "requirements.txt"})
 		},
 		ListSpecfile: func() map[api.PkgName]api.PkgSpec {
-			flags, rawPkgs, err := ListRequirementsTxt("requirements.txt")
+			flags, pkgs, err := ListRequirementsTxt("requirements.txt")
 			if err != nil {
 				util.Die("%s", err.Error())
-			}
-
-			normalizedPkgs := make(map[api.PkgName]api.PkgSpec)
-			for name, spec := range rawPkgs {
-				normalizedPkgs[normalizePackageName(name)] = spec
 			}
 
 			// Stash the seen flags into a module global.
@@ -458,7 +453,10 @@ func makePythonPipBackend(python string) api.LanguageBackend {
 			// is called before we run `Add`.
 			pipFlags = flags
 
-			return normalizedPkgs
+			// NB: We rely on requirements.txt being populated with the
+			// Python package _metadata_ name, not the PEP-503/PEP-508
+			// normalized version.
+			return pkgs
 		},
 		GuessRegexps: pythonGuessRegexps,
 		Guess:        func(ctx context.Context) (map[api.PkgName]bool, bool) { return guess(ctx, python) },


### PR DESCRIPTION
Unfortunately, even [normalization rules](https://packaging.python.org/en/latest/specifications/name-normalization/) are not the end of the story when it comes to `pip freeze`!

`pip install discord-py` will still result in `pip freeze | grep discord` == `discord.py`, since that's the name tracked in the metadata.

Exciting!