### PR TITLE
[python_map] remove spacy deps

### DIFF
--- a/internal/nix/python_map.json
+++ b/internal/nix/python_map.json
@@ -652,7 +652,6 @@
   "sounddevice":{"deps":["pkgs.portaudio"]},
   "soundfile":{"deps":["pkgs.libsndfile"]},
   "soxr":{"deps":["pkgs.gnutar"]},
-  "spacy":{"deps":["pkgs.gitFull","pkgs.nix","pkgs.nix-update"]},
   "spacy-alignments":{"deps":["pkgs.cargo","pkgs.libiconv","pkgs.rustc"]},
   "sphinx-issues":{"deps":["pkgs.pandoc"]},
   "sphinxcontrib-mscgen":{"deps":["pkgs.mscgen"]},


### PR DESCRIPTION
Why
===
* These deps were only necessary for the nixpkgs updater in nixpkgs, they aren't necessary for this package

What changed
===
* Removed unneeded deps

Test plan
===
* Install spacy with poetry and confirm running does not add nix-update to replit.nix