### PR TITLE
bug/Differentiate exit codes

### DIFF
--- a/internal/backends/backends.go
+++ b/internal/backends/backends.go
@@ -90,7 +90,7 @@ func GetBackend(ctx context.Context, language string) api.LanguageBackend {
 		}
 		switch len(filteredBackends) {
 		case 0:
-			util.Die("no such language: %s", language)
+			util.DieConsistency("no such language: %s", language)
 		case 1:
 			return filteredBackends[0]
 		default:

--- a/internal/backends/backends.go
+++ b/internal/backends/backends.go
@@ -118,7 +118,7 @@ func GetBackend(ctx context.Context, language string) api.LanguageBackend {
 		}
 	}
 	if language == "" {
-		util.Die("could not autodetect a language for your project")
+		util.DieInitializationError("could not autodetect a language for your project")
 	}
 	return backends[0]
 }

--- a/internal/backends/dart/dart.go
+++ b/internal/backends/dart/dart.go
@@ -294,7 +294,7 @@ func dartRemove(ctx context.Context, pkgs map[api.PkgName]bool) {
 
 // dartGuess stub.
 func dartGuess(context.Context) (map[string][]api.PkgName, bool) {
-	util.Die("Guess not implemented!")
+	util.DieUnimplemented("Guess not implemented!")
 
 	return nil, false
 }

--- a/internal/backends/dart/dart.go
+++ b/internal/backends/dart/dart.go
@@ -142,12 +142,12 @@ func dartSearch(query string) []api.PkgInfo {
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		util.Die("Pub.dev: %s", err)
+		util.DieProtocol("Pub.dev: %s", err)
 	}
 
 	var pubDevResults pubDevSearchResults
 	if err := json.Unmarshal(body, &pubDevResults); err != nil {
-		util.Die("Pub.dev: %s", err)
+		util.DieProtocol("Pub.dev: %s", err)
 	}
 
 	results := make([]api.PkgInfo, len(pubDevResults.Packages))
@@ -195,12 +195,12 @@ func dartInfo(name api.PkgName) api.PkgInfo {
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		util.Die("Pub.dev: %s", err)
+		util.DieProtocol("Pub.dev: %s", err)
 	}
 
 	var pubDevResults pubDevInfoResults
 	if err := json.Unmarshal(body, &pubDevResults); err != nil {
-		util.Die("Pub.dev: %s", err)
+		util.DieProtocol("Pub.dev: %s", err)
 	}
 
 	return api.PkgInfo{

--- a/internal/backends/dart/dart.go
+++ b/internal/backends/dart/dart.go
@@ -128,7 +128,7 @@ func dartSearch(query string) []api.PkgInfo {
 
 	req, err := http.NewRequest("GET", endpoint, nil)
 	if err != nil {
-		util.Die("Pub.dev: %s", err)
+		util.DieNetwork("Pub.dev: %s", err)
 	}
 
 	req.Header.Add("Accept", "application/json")
@@ -136,7 +136,7 @@ func dartSearch(query string) []api.PkgInfo {
 	resp, err := api.HttpClient.Do(req)
 
 	if err != nil {
-		util.Die("Pub.dev: %s", err)
+		util.DieNetwork("Pub.dev: %s", err)
 	}
 	defer resp.Body.Close()
 
@@ -182,14 +182,14 @@ func dartInfo(name api.PkgName) api.PkgInfo {
 
 	req, err := http.NewRequest("GET", endpoint, nil)
 	if err != nil {
-		util.Die("Pub.dev: %s", err)
+		util.DieNetwork("Pub.dev: %s", err)
 	}
 
 	req.Header.Add("Accept", "application/json")
 
 	resp, err := api.HttpClient.Do(req)
 	if err != nil {
-		util.Die("Pub.dev: %s", err)
+		util.DieNetwork("Pub.dev: %s", err)
 	}
 	defer resp.Body.Close()
 

--- a/internal/backends/dart/dart.go
+++ b/internal/backends/dart/dart.go
@@ -100,11 +100,11 @@ type dartPubspecLock struct {
 func dartListPubspecLock() map[api.PkgName]api.PkgVersion {
 	contentsB, err := os.ReadFile("pubspec.lock")
 	if err != nil {
-		util.Die("pubspec.lock: %s", err)
+		util.DieIO("pubspec.lock: %s", err)
 	}
 	var cfg dartPubspecLock
 	if err := yaml.Unmarshal(contentsB, &cfg); err != nil {
-		util.Die("pubspec.lock: %s", err)
+		util.DieIO("pubspec.lock: %s", err)
 	}
 	pkgs := map[api.PkgName]api.PkgVersion{}
 	for nameStr, data := range cfg.Packages {
@@ -246,12 +246,12 @@ func writeSpecFile(specs dartPubspecYaml) {
 func readSpecFile() dartPubspecYaml {
 	contentsB, err := os.ReadFile("pubspec.yaml")
 	if err != nil {
-		util.Die("pubspec.yaml: %s", err)
+		util.DieIO("pubspec.yaml: %s", err)
 	}
 
 	var specs dartPubspecYaml
 	if err := yaml.Unmarshal(contentsB, &specs); err != nil {
-		util.Die("pubspec.yaml: %s", err)
+		util.DieIO("pubspec.yaml: %s", err)
 	}
 
 	return specs

--- a/internal/backends/dart/dart.go
+++ b/internal/backends/dart/dart.go
@@ -220,7 +220,7 @@ func dartInfo(name api.PkgName) api.PkgInfo {
 
 func createSpecFile() {
 	if util.Exists("pubspec.yaml") {
-		util.Die("pubspec.yaml already exists")
+		util.DieOverwrite("pubspec.yaml already exists")
 	}
 
 	pubspec := dartPubspecYaml{

--- a/internal/backends/dotnet/nuget.go
+++ b/internal/backends/dotnet/nuget.go
@@ -70,7 +70,7 @@ func search(query string) []api.PkgInfo {
 
 	res, err := api.HttpClient.Get(queryURL)
 	if err != nil {
-		util.Die("failed to query for packages: %s", err)
+		util.DieNetwork("failed to query for packages: %s", err)
 	}
 	defer res.Body.Close()
 
@@ -108,7 +108,7 @@ func info(pkgName api.PkgName) api.PkgInfo {
 
 	res, err := api.HttpClient.Get(infoURL)
 	if err != nil {
-		util.Die("failed to get the versions: %s", err)
+		util.DieNetwork("failed to get the versions: %s", err)
 	}
 	defer res.Body.Close()
 	body, err := io.ReadAll(res.Body)
@@ -126,7 +126,7 @@ func info(pkgName api.PkgName) api.PkgInfo {
 	util.ProgressMsg(fmt.Sprintf("Getting spec from %s", specURL))
 	res, err = api.HttpClient.Get(specURL)
 	if err != nil {
-		util.Die("failed to get the spec: %s", err)
+		util.DieNetwork("failed to get the spec: %s", err)
 	}
 	defer res.Body.Close()
 	body, err = io.ReadAll(res.Body)

--- a/internal/backends/dotnet/nuget.go
+++ b/internal/backends/dotnet/nuget.go
@@ -80,13 +80,13 @@ func search(query string) []api.PkgInfo {
 
 	body, err := io.ReadAll(res.Body)
 	if err != nil {
-		util.Die("Could not read response: %s", err)
+		util.DieProtocol("Could not read response: %s", err)
 	}
 
 	var searchResult searchResult
 	err = json.Unmarshal(body, &searchResult)
 	if err != nil {
-		util.Die("Could not unmarshal response data: %s", err)
+		util.DieProtocol("Could not unmarshal response data: %s", err)
 	}
 
 	for _, data := range searchResult.Data {
@@ -113,12 +113,12 @@ func info(pkgName api.PkgName) api.PkgInfo {
 	defer res.Body.Close()
 	body, err := io.ReadAll(res.Body)
 	if err != nil {
-		util.Die("could not read response: %s", err)
+		util.DieProtocol("could not read response: %s", err)
 	}
 	var infoResult infoResult
 	err = json.Unmarshal(body, &infoResult)
 	if err != nil {
-		util.Die("could not read json body: %s", err)
+		util.DieProtocol("could not read json body: %s", err)
 	}
 	latestVersion := infoResult.Versions[len(infoResult.Versions)-1]
 	util.ProgressMsg(fmt.Sprintf("latest version of %s is %s", pkgName, latestVersion))
@@ -131,12 +131,12 @@ func info(pkgName api.PkgName) api.PkgInfo {
 	defer res.Body.Close()
 	body, err = io.ReadAll(res.Body)
 	if err != nil {
-		util.Die("could not read response: %s", err)
+		util.DieProtocol("could not read response: %s", err)
 	}
 	var nugetPackage nugetPackage
 	err = xml.Unmarshal(body, &nugetPackage)
 	if err != nil {
-		util.Die(fmt.Sprintf("failed to read spec %s", err))
+		util.DieProtocol(fmt.Sprintf("failed to read spec %s", err))
 	}
 
 	pkgInfo := api.PkgInfo{

--- a/internal/backends/dotnet/project_files.go
+++ b/internal/backends/dotnet/project_files.go
@@ -32,7 +32,7 @@ type project struct {
 func findSpecFile() string {
 	files, err := os.ReadDir("./")
 	if err != nil {
-		util.Die("can't read current directory: %s", err)
+		util.DieIO("can't read current directory: %s", err)
 	}
 
 	for _, f := range files {
@@ -53,7 +53,7 @@ func listSpecfile() map[api.PkgName]api.PkgSpec {
 		return pkgs
 	}
 	if err != nil {
-		util.Die("Could not open %s, with error: %q", projectFile, err)
+		util.DieIO("Could not open %s, with error: %q", projectFile, err)
 	}
 	defer specReader.Close()
 
@@ -96,7 +96,7 @@ func listLockfile() map[api.PkgName]api.PkgVersion {
 		return pkgs
 	}
 	if err != nil {
-		util.Die("Could not open %s, with error: %q", lockFileName, err)
+		util.DieIO("Could not open %s, with error: %q", lockFileName, err)
 	}
 	defer specReader.Close()
 

--- a/internal/backends/dotnet/project_files.go
+++ b/internal/backends/dotnet/project_files.go
@@ -59,7 +59,7 @@ func listSpecfile() map[api.PkgName]api.PkgSpec {
 
 	pkgs, err = ReadSpec(specReader)
 	if err != nil {
-		util.Die("Failed to read spec file %s, with error: %q", projectFile, err)
+		util.DieProtocol("Failed to read spec file %s, with error: %q", projectFile, err)
 	}
 
 	return pkgs
@@ -102,7 +102,7 @@ func listLockfile() map[api.PkgName]api.PkgVersion {
 
 	pkgs, err = ReadLock(specReader)
 	if err != nil {
-		util.Die("error reading lockFile %s: %q", lockFileName, err)
+		util.DieProtocol("error reading lockFile %s: %q", lockFileName, err)
 	}
 
 	return pkgs

--- a/internal/backends/elisp/elisp.go
+++ b/internal/backends/elisp/elisp.go
@@ -42,7 +42,7 @@ var ElispBackend = api.LanguageBackend{
 	Search: func(query string) []api.PkgInfo {
 		tmpdir, err := os.MkdirTemp("", "elpa")
 		if err != nil {
-			util.Die("%s", err)
+			util.DieIO("%s", err)
 		}
 		defer os.RemoveAll(tmpdir)
 
@@ -66,7 +66,7 @@ var ElispBackend = api.LanguageBackend{
 	Info: func(name api.PkgName) api.PkgInfo {
 		tmpdir, err := os.MkdirTemp("", "elpa")
 		if err != nil {
-			util.Die("%s", err)
+			util.DieIO("%s", err)
 		}
 		defer os.RemoveAll(tmpdir)
 
@@ -99,7 +99,7 @@ var ElispBackend = api.LanguageBackend{
 (source org)
 `
 		} else if err != nil {
-			util.Die("Cask: %s", err)
+			util.DieIO("Cask: %s", err)
 		} else {
 			contents = string(contentsB)
 		}
@@ -128,7 +128,7 @@ var ElispBackend = api.LanguageBackend{
 		defer span.Finish()
 		contentsB, err := os.ReadFile("Cask")
 		if err != nil {
-			util.Die("Cask: %s", err)
+			util.DieIO("Cask: %s", err)
 		}
 		contents := string(contentsB)
 
@@ -182,7 +182,7 @@ var ElispBackend = api.LanguageBackend{
 	ListLockfile: func() map[api.PkgName]api.PkgVersion {
 		contentsB, err := os.ReadFile("packages.txt")
 		if err != nil {
-			util.Die("packages.txt: %s", err)
+			util.DieIO("packages.txt: %s", err)
 		}
 		contents := string(contentsB)
 		r := regexp.MustCompile(`(.+)=(.+)`)
@@ -223,7 +223,7 @@ var ElispBackend = api.LanguageBackend{
 
 		tempdir, err := os.MkdirTemp("", "epkgs")
 		if err != nil {
-			util.Die("%s", err)
+			util.DieIO("%s", err)
 		}
 		defer os.RemoveAll(tempdir)
 

--- a/internal/backends/elisp/elisp.go
+++ b/internal/backends/elisp/elisp.go
@@ -59,7 +59,7 @@ var ElispBackend = api.LanguageBackend{
 		})
 		var results []api.PkgInfo
 		if err := json.Unmarshal(outputB, &results); err != nil {
-			util.Die("%s", err)
+			util.DieProtocol("%s", err)
 		}
 		return results
 	},
@@ -83,7 +83,7 @@ var ElispBackend = api.LanguageBackend{
 		})
 		var info api.PkgInfo
 		if err := json.Unmarshal(outputB, &info); err != nil {
-			util.Die("%s", err)
+			util.DieProtocol("%s", err)
 		}
 		return info
 	},
@@ -171,7 +171,7 @@ var ElispBackend = api.LanguageBackend{
 			}
 			fields := strings.SplitN(line, "=", 2)
 			if len(fields) != 2 {
-				util.Die("unexpected output: %s", line)
+				util.DieProtocol("unexpected output, expected name=spec: %s", line)
 			}
 			name := api.PkgName(fields[0])
 			spec := api.PkgSpec(fields[1])

--- a/internal/backends/java/java.go
+++ b/internal/backends/java/java.go
@@ -109,7 +109,7 @@ func readProjectOrMakeEmpty(path string) Project {
 	}
 	err := xml.Unmarshal(xmlbytes, &project)
 	if err != nil {
-		util.Die("error unmarshalling pom.xml: %s", err)
+		util.DieProtocol("error unmarshalling pom.xml: %s", err)
 	}
 	return project
 }
@@ -203,7 +203,7 @@ func addPackages(ctx context.Context, pkgs map[api.PkgName]api.PkgSpec, projectN
 	project.Dependencies = append(project.Dependencies, newDependencies...)
 	marshalled, err := xml.MarshalIndent(project, "", "  ")
 	if err != nil {
-		util.Die("could not marshal pom: %s", err)
+		util.DieProtocol("could not marshal pom: %s", err)
 	}
 
 	contentsB := []byte(marshalled)
@@ -234,7 +234,7 @@ func removePackages(ctx context.Context, pkgs map[api.PkgName]bool) {
 
 	marshalled, err := xml.MarshalIndent(projectWithFilteredDependencies, "", "  ")
 	if err != nil {
-		util.Die("error marshalling pom.xml: %s", err)
+		util.DieProtocol("error marshalling pom.xml: %s", err)
 	}
 	contentsB := []byte(marshalled)
 	util.ProgressMsg("write pom.xml")

--- a/internal/backends/java/java.go
+++ b/internal/backends/java/java.go
@@ -160,7 +160,7 @@ func addPackages(ctx context.Context, pkgs map[api.PkgName]api.PkgSpec, projectN
 		}
 		searchDocs, err := Search(query)
 		if err != nil {
-			util.Die(
+			util.DieNetwork(
 				"error searching maven for latest version of %s:%s: %s",
 				groupId,
 				artifactId,
@@ -272,7 +272,7 @@ func listLockfile() map[api.PkgName]api.PkgVersion {
 func search(query string) []api.PkgInfo {
 	searchDocs, err := Search(query)
 	if err != nil {
-		util.Die("error searching maven %s", err)
+		util.DieNetwork("error searching maven %s", err)
 	}
 	pkgInfos := []api.PkgInfo{}
 	for _, searchDoc := range searchDocs {
@@ -289,7 +289,7 @@ func info(pkgName api.PkgName) api.PkgInfo {
 	searchDoc, err := Info(string(pkgName))
 
 	if err != nil {
-		util.Die("error searching maven %s", err)
+		util.DieNetwork("error searching maven %s", err)
 	}
 
 	if searchDoc.Artifact == "" {

--- a/internal/backends/java/java.go
+++ b/internal/backends/java/java.go
@@ -102,7 +102,7 @@ func readProjectOrMakeEmpty(path string) Project {
 		var err error
 		xmlbytes, err = os.ReadFile("pom.xml")
 		if err != nil {
-			util.Die("error reading pom.xml: %s", err)
+			util.DieIO("error reading pom.xml: %s", err)
 		}
 	} else {
 		xmlbytes = []byte(initialPomXml)

--- a/internal/backends/java/java.go
+++ b/internal/backends/java/java.go
@@ -139,7 +139,7 @@ func addPackages(ctx context.Context, pkgs map[api.PkgName]api.PkgSpec, projectN
 	for pkgName, pkgSpec := range pkgs {
 		submatches := pkgNameRegexp.FindStringSubmatch(string(pkgName))
 		if nil == submatches {
-			util.Die(
+			util.DieConsistency(
 				"package name %s does not match groupid:artifactid pattern",
 				pkgName,
 			)
@@ -169,9 +169,9 @@ func addPackages(ctx context.Context, pkgs map[api.PkgName]api.PkgSpec, projectN
 		}
 		if len(searchDocs) == 0 {
 			if pkgSpec == "" {
-				util.Die("did not find a package %s:%s", groupId, artifactId)
+				util.DieConsistency("did not find a package %s:%s", groupId, artifactId)
 			} else {
-				util.Die("did not find a package %s:%s:%s", groupId, artifactId, pkgSpec)
+				util.DieConsistency("did not find a package %s:%s:%s", groupId, artifactId, pkgSpec)
 			}
 		}
 		searchDoc := searchDocs[0]

--- a/internal/backends/nodejs/grab.go
+++ b/internal/backends/nodejs/grab.go
@@ -62,7 +62,7 @@ func nodejsGuess(ctx context.Context) (map[string][]api.PkgName, bool) {
 	defer span.Finish()
 	cwd, err := os.Getwd()
 	if err != nil {
-		util.Die("couldn't get working directory: %s", err)
+		util.DieIO("couldn't get working directory: %s", err)
 	}
 
 	foundImportPaths, err := findImports(ctx, cwd)

--- a/internal/backends/nodejs/grab.go
+++ b/internal/backends/nodejs/grab.go
@@ -67,7 +67,7 @@ func nodejsGuess(ctx context.Context) (map[string][]api.PkgName, bool) {
 
 	foundImportPaths, err := findImports(ctx, cwd)
 	if err != nil {
-		util.Die("couldn't guess imports: %s", err)
+		util.DieConsistency("couldn't guess imports: %s", err)
 	}
 
 	return filterImports(ctx, foundImportPaths), true

--- a/internal/backends/nodejs/nodejs.go
+++ b/internal/backends/nodejs/nodejs.go
@@ -242,12 +242,12 @@ func nodejsSearch(query string) []api.PkgInfo {
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		util.Die("NPM registry: %s", err)
+		util.DieProtocol("NPM registry: %s", err)
 	}
 
 	var npmResults npmSearchResults
 	if err := json.Unmarshal(body, &npmResults); err != nil {
-		util.Die("NPM registry: %s", err)
+		util.DieProtocol("NPM registry: %s", err)
 	}
 
 	results := make([]api.PkgInfo, len(npmResults.Objects))
@@ -291,12 +291,12 @@ func nodejsInfo(name api.PkgName) api.PkgInfo {
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		util.Die("NPM registry: could not read response: %s", err)
+		util.DieProtocol("NPM registry: could not read response: %s", err)
 	}
 
 	var npmInfo npmInfoResult
 	if err := json.Unmarshal(body, &npmInfo); err != nil {
-		util.Die("NPM registry: %s", err)
+		util.DieProtocol("NPM registry: %s", err)
 	}
 
 	lastVersionStr := ""
@@ -346,7 +346,7 @@ func nodejsListSpecfile() map[api.PkgName]api.PkgSpec {
 	}
 	var cfg packageJSON
 	if err := json.Unmarshal(contentsB, &cfg); err != nil {
-		util.Die("package.json: %s", err)
+		util.DieProtocol("package.json: %s", err)
 	}
 	pkgs := map[api.PkgName]api.PkgSpec{}
 	for nameStr, specStr := range cfg.Dependencies {
@@ -533,7 +533,7 @@ var NodejsPNPMBackend = api.LanguageBackend{
 		lockfile := map[string]interface{}{}
 		err = yaml.Unmarshal(lockfileBytes, &lockfile)
 		if err != nil {
-			util.Die("pnpm-lock.yaml: %s", err)
+			util.DieProtocol("pnpm-lock.yaml: %s", err)
 		}
 
 		lockfileVersion := strings.Split(lockfile["lockfileVersion"].(string), ".")
@@ -625,7 +625,7 @@ var NodejsNPMBackend = api.LanguageBackend{
 		}
 		var cfg packageLockJSON
 		if err := json.Unmarshal(contentsB, &cfg); err != nil {
-			util.Die("package-lock.json: %s", err)
+			util.DieProtocol("package-lock.json: %s", err)
 		}
 		pkgs := map[api.PkgName]api.PkgVersion{}
 		if cfg.LockfileVersion <= 2 {

--- a/internal/backends/nodejs/nodejs.go
+++ b/internal/backends/nodejs/nodejs.go
@@ -342,7 +342,7 @@ func nodejsInfo(name api.PkgName) api.PkgInfo {
 func nodejsListSpecfile() map[api.PkgName]api.PkgSpec {
 	contentsB, err := os.ReadFile("package.json")
 	if err != nil {
-		util.Die("package.json: %s", err)
+		util.DieIO("package.json: %s", err)
 	}
 	var cfg packageJSON
 	if err := json.Unmarshal(contentsB, &cfg); err != nil {
@@ -451,7 +451,7 @@ var NodejsYarnBackend = api.LanguageBackend{
 	ListLockfile: func() map[api.PkgName]api.PkgVersion {
 		contentsB, err := os.ReadFile("yarn.lock")
 		if err != nil {
-			util.Die("yarn.lock: %s", err)
+			util.DieIO("yarn.lock: %s", err)
 		}
 		contents := string(contentsB)
 		r := regexp.MustCompile(`(?m)^"?((?:@[^@ \n]+\/)?[^@ \n]+).+:\n  version "(.+)"$`)
@@ -527,7 +527,7 @@ var NodejsPNPMBackend = api.LanguageBackend{
 	ListLockfile: func() map[api.PkgName]api.PkgVersion {
 		lockfileBytes, err := os.ReadFile("pnpm-lock.yaml")
 		if err != nil {
-			util.Die("pnpm-lock.yaml: %s", err)
+			util.DieIO("pnpm-lock.yaml: %s", err)
 		}
 
 		lockfile := map[string]interface{}{}
@@ -621,7 +621,7 @@ var NodejsNPMBackend = api.LanguageBackend{
 	ListLockfile: func() map[api.PkgName]api.PkgVersion {
 		contentsB, err := os.ReadFile("package-lock.json")
 		if err != nil {
-			util.Die("package-lock.json: %s", err)
+			util.DieIO("package-lock.json: %s", err)
 		}
 		var cfg packageLockJSON
 		if err := json.Unmarshal(contentsB, &cfg); err != nil {

--- a/internal/backends/nodejs/nodejs.go
+++ b/internal/backends/nodejs/nodejs.go
@@ -552,7 +552,7 @@ var NodejsPNPMBackend = api.LanguageBackend{
 			}
 
 		default:
-			util.Die("pnpm-lock.yaml: unsupported lockfile version %s", lockfileVersion)
+			util.DieInitializationError("pnpm-lock.yaml: unsupported lockfile version %s", lockfileVersion)
 		}
 
 		return pkgs

--- a/internal/backends/nodejs/nodejs.go
+++ b/internal/backends/nodejs/nodejs.go
@@ -236,7 +236,7 @@ func nodejsSearch(query string) []api.PkgInfo {
 
 	resp, err := api.HttpClient.Get(endpoint + queryParams)
 	if err != nil {
-		util.Die("NPM registry: %s", err)
+		util.DieNetwork("NPM registry: %s", err)
 	}
 	defer resp.Body.Close()
 
@@ -276,7 +276,7 @@ func nodejsInfo(name api.PkgName) api.PkgInfo {
 
 	resp, err := api.HttpClient.Get(endpoint + path)
 	if err != nil {
-		util.Die("NPM registry: %s", err)
+		util.DieNetwork("NPM registry: %s", err)
 	}
 	defer resp.Body.Close()
 
@@ -286,7 +286,7 @@ func nodejsInfo(name api.PkgName) api.PkgInfo {
 	case 404:
 		return api.PkgInfo{}
 	default:
-		util.Die("NPM registry: HTTP status %d", resp.StatusCode)
+		util.DieNetwork("NPM registry: HTTP status %d", resp.StatusCode)
 	}
 
 	body, err := io.ReadAll(resp.Body)

--- a/internal/backends/nodejs/nodejs.go
+++ b/internal/backends/nodejs/nodejs.go
@@ -706,7 +706,7 @@ var BunBackend = api.LanguageBackend{
 	ListLockfile: func() map[api.PkgName]api.PkgVersion {
 		hashString, err := exec.Command("bun", "pm", "hash-string").Output()
 		if err != nil {
-			util.Die("bun pm hash-string: %s", err)
+			util.DieSubprocess("bun pm hash-string: %s", err)
 		}
 
 		r := regexp.MustCompile(`(?m)^(@?[^@ \n]+)@(.+)$`)

--- a/internal/backends/php/php.go
+++ b/internal/backends/php/php.go
@@ -74,7 +74,7 @@ func search(query string) []api.PkgInfo {
 	resp, err := api.HttpClient.Get(endpoint)
 
 	if err != nil {
-		util.Die("packagist search err: %s", err)
+		util.DieNetwork("packagist search err: %s", err)
 	}
 
 	defer resp.Body.Close()
@@ -118,7 +118,7 @@ func info(name api.PkgName) api.PkgInfo {
 	resp, err := api.HttpClient.Get(endpoint)
 
 	if err != nil {
-		util.Die("packagist err: %s", err)
+		util.DieNetwork("packagist err: %s", err)
 	}
 
 	defer resp.Body.Close()

--- a/internal/backends/php/php.go
+++ b/internal/backends/php/php.go
@@ -81,13 +81,13 @@ func search(query string) []api.PkgInfo {
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		util.Die("packagist err: %s", err)
+		util.DieProtocol("packagist err: %s", err)
 	}
 
 	pkgInfo, err := parseSearch(body)
 
 	if err != nil {
-		util.Die("Error: %s", err)
+		util.DieProtocol("Error: %s", err)
 	}
 
 	return pkgInfo
@@ -125,13 +125,13 @@ func info(name api.PkgName) api.PkgInfo {
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		util.Die("packagist err: %s", err)
+		util.DieProtocol("packagist err: %s", err)
 	}
 
 	pkgInfo, err := parseInfo(body, name)
 
 	if err != nil {
-		util.Die("Error: %s", err)
+		util.DieProtocol("Error: %s", err)
 	}
 
 	return pkgInfo
@@ -190,7 +190,7 @@ func listSpecfileWithContents(contents []byte) map[api.PkgName]api.PkgSpec {
 	}
 
 	if err := json.Unmarshal(contents, &specfile); err != nil {
-		util.Die("composer.json: %s", err)
+		util.DieProtocol("composer.json: %s", err)
 	}
 
 	packages := make(map[api.PkgName]api.PkgSpec)
@@ -217,7 +217,7 @@ func listLockfile() map[api.PkgName]api.PkgVersion {
 func listLockfileWithContents(contents []byte) map[api.PkgName]api.PkgVersion {
 	var composerLock composerLock
 	if err := json.Unmarshal(contents, &composerLock); err != nil {
-		util.Die("composer.lock err: %s", err)
+		util.DieProtocol("composer.lock err: %s", err)
 	}
 
 	packages := make(map[api.PkgName]api.PkgVersion)

--- a/internal/backends/php/php.go
+++ b/internal/backends/php/php.go
@@ -177,7 +177,7 @@ func listSpecfile() map[api.PkgName]api.PkgSpec {
 	contents, err := os.ReadFile("composer.json")
 
 	if err != nil {
-		util.Die("composer.json: %s", err)
+		util.DieIO("composer.json: %s", err)
 	}
 
 	return listSpecfileWithContents(contents)
@@ -209,7 +209,7 @@ func listSpecfileWithContents(contents []byte) map[api.PkgName]api.PkgSpec {
 func listLockfile() map[api.PkgName]api.PkgVersion {
 	contents, err := os.ReadFile("composer.lock")
 	if err != nil {
-		util.Die("composer.lock failure: %s", err)
+		util.DieIO("composer.lock failure: %s", err)
 	}
 	return listLockfileWithContents(contents)
 }

--- a/internal/backends/python/grab.go
+++ b/internal/backends/python/grab.go
@@ -254,7 +254,7 @@ func guess(ctx context.Context, python string) (map[string][]api.PkgName, bool) 
 
 	foundImportPaths, err := findImports(ctx, cwd)
 	if err != nil {
-		util.Die("couldn't guess imports: %s", err)
+		util.DieConsistency("couldn't guess imports: %s", err)
 	}
 
 	return filterImports(ctx, foundImportPaths)
@@ -292,7 +292,7 @@ func filterImports(ctx context.Context, foundPkgs map[string]bool) (map[string][
 
 	pypiMap, err := NewPypiMap()
 	if err != nil {
-		util.Die(err.Error())
+		util.DieConsistency(err.Error())
 	}
 	defer pypiMap.Close()
 

--- a/internal/backends/python/grab.go
+++ b/internal/backends/python/grab.go
@@ -249,7 +249,7 @@ func guess(ctx context.Context, python string) (map[string][]api.PkgName, bool) 
 	defer span.Finish()
 	cwd, err := os.Getwd()
 	if err != nil {
-		util.Die("couldn't get working directory: %s", err)
+		util.DieIO("couldn't get working directory: %s", err)
 	}
 
 	foundImportPaths, err := findImports(ctx, cwd)

--- a/internal/backends/python/python.go
+++ b/internal/backends/python/python.go
@@ -395,7 +395,7 @@ func makePythonPipBackend(python string) api.LanguageBackend {
 				"pip", "freeze",
 			})
 			if err != nil {
-				util.Die("failed to run freeze: %s", err.Error())
+				util.DieSubprocess("failed to run freeze: %s", err.Error())
 			}
 
 			// As we walk through the output of pip freeze,

--- a/internal/backends/python/python.go
+++ b/internal/backends/python/python.go
@@ -110,7 +110,7 @@ func info(name api.PkgName) api.PkgInfo {
 	res, err := api.HttpClient.Get(fmt.Sprintf("https://pypi.org/pypi/%s/json", string(name)))
 
 	if err != nil {
-		util.Die("HTTP Request failed with error: %s", err)
+		util.DieNetwork("HTTP Request failed with error: %s", err)
 	}
 
 	defer res.Body.Close()
@@ -120,7 +120,7 @@ func info(name api.PkgName) api.PkgInfo {
 	}
 
 	if res.StatusCode != 200 {
-		util.Die("Received status code: %d", res.StatusCode)
+		util.DieNetwork("Received status code: %d", res.StatusCode)
 	}
 
 	body, err := io.ReadAll(res.Body)
@@ -205,7 +205,7 @@ func searchPypi(query string) []api.PkgInfo {
 	}
 	results, err := SearchPypi(query)
 	if err != nil {
-		util.Die("failed to search pypi: %s", err.Error())
+		util.DieNetwork("failed to search pypi: %s", err.Error())
 	}
 	return results
 }

--- a/internal/backends/python/python.go
+++ b/internal/backends/python/python.go
@@ -125,12 +125,12 @@ func info(name api.PkgName) api.PkgInfo {
 
 	body, err := io.ReadAll(res.Body)
 	if err != nil {
-		util.Die("Res body read failed with error: %s", err)
+		util.DieProtocol("Res body read failed with error: %s", err)
 	}
 
 	var output pypiEntryInfoResponse
 	if err := json.Unmarshal(body, &output); err != nil {
-		util.Die("PyPI response: %s", err)
+		util.DieProtocol("PyPI response: %s", err)
 	}
 
 	info := api.PkgInfo{
@@ -292,7 +292,7 @@ func makePythonPoetryBackend(python string) api.LanguageBackend {
 		ListLockfile: func() map[api.PkgName]api.PkgVersion {
 			var cfg poetryLock
 			if _, err := toml.DecodeFile("poetry.lock", &cfg); err != nil {
-				util.Die("%s", err.Error())
+				util.DieProtocol("%s", err.Error())
 			}
 			pkgs := map[api.PkgName]api.PkgVersion{}
 			for _, pkgObj := range cfg.Package {

--- a/internal/backends/python/python.go
+++ b/internal/backends/python/python.go
@@ -284,7 +284,7 @@ func makePythonPoetryBackend(python string) api.LanguageBackend {
 		ListSpecfile: func() map[api.PkgName]api.PkgSpec {
 			pkgs, err := listPoetrySpecfile()
 			if err != nil {
-				util.Die("%s", err.Error())
+				util.DieIO("%s", err.Error())
 			}
 
 			return pkgs
@@ -421,12 +421,12 @@ func makePythonPipBackend(python string) api.LanguageBackend {
 
 			handle, err := os.OpenFile("requirements.txt", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
 			if err != nil {
-				util.Die("Unable to open requirements.txt for writing: %s", err)
+				util.DieIO("Unable to open requirements.txt for writing: %s", err)
 			}
 			defer handle.Close()
 			for _, line := range toAppend {
 				if _, err := handle.WriteString(line + "\n"); err != nil {
-					util.Die("Error writing to requirements.txt: %s", err)
+					util.DieIO("Error writing to requirements.txt: %s", err)
 				}
 			}
 		},
@@ -442,7 +442,7 @@ func makePythonPipBackend(python string) api.LanguageBackend {
 			util.RunCmd(cmd)
 			err := RemoveFromRequirementsTxt("requirements.txt", pkgs)
 			if err != nil {
-				util.Die("%s", err.Error())
+				util.DieIO("%s", err.Error())
 			}
 		},
 		Install: func(ctx context.Context) {
@@ -455,7 +455,7 @@ func makePythonPipBackend(python string) api.LanguageBackend {
 		ListSpecfile: func() map[api.PkgName]api.PkgSpec {
 			flags, pkgs, err := ListRequirementsTxt("requirements.txt")
 			if err != nil {
-				util.Die("%s", err.Error())
+				util.DieIO("%s", err.Error())
 			}
 
 			// Stash the seen flags into a module global.

--- a/internal/backends/python/requirements.go
+++ b/internal/backends/python/requirements.go
@@ -72,7 +72,7 @@ func findPackage(line string) (*api.PkgName, *api.PkgSpec, bool) {
 func recurseRequirementsTxt(depth int, path string, sofar map[api.PkgName]api.PkgSpec, constraints Constraints) ([]PipFlag, map[api.PkgName]api.PkgSpec, Constraints, error) {
 	// Perhaps this can be lifted, but sensibly attempt to protect ourselves
 	if depth > 10 {
-		util.Die("Too many -r redirects in %s", path)
+		util.DieConsistency("Too many -r redirects in %s", path)
 	}
 
 	var flags []PipFlag
@@ -138,7 +138,7 @@ func ListRequirementsTxt(path string) ([]PipFlag, map[api.PkgName]api.PkgSpec, e
 
 func recurseRemoveFromRequirementsTxt(depth int, path string, pkgs map[api.PkgName]bool) error {
 	if depth > 10 {
-		util.Die("Too many -r redirects in %s", path)
+		util.DieConsistency("Too many -r redirects in %s", path)
 	}
 
 	var lines []string

--- a/internal/backends/ruby/ruby.go
+++ b/internal/backends/ruby/ruby.go
@@ -93,7 +93,7 @@ var RubyBackend = api.LanguageBackend{
 
 		resp, err := api.HttpClient.Get(endpoint + queryParams)
 		if err != nil {
-			util.Die("RubyGems: %s", err)
+			util.DieNetwork("RubyGems: %s", err)
 		}
 		defer resp.Body.Close()
 
@@ -136,7 +136,7 @@ var RubyBackend = api.LanguageBackend{
 
 		resp, err := api.HttpClient.Get(endpoint + path)
 		if err != nil {
-			util.Die("RubyGems: %s", err)
+			util.DieNetwork("RubyGems: %s", err)
 		}
 		defer resp.Body.Close()
 
@@ -146,7 +146,7 @@ var RubyBackend = api.LanguageBackend{
 		case 404:
 			return api.PkgInfo{}
 		default:
-			util.Die("RubyGems: HTTP status %d", resp.StatusCode)
+			util.DieNetwork("RubyGems: HTTP status %d", resp.StatusCode)
 		}
 
 		body, err := io.ReadAll(resp.Body)

--- a/internal/backends/ruby/ruby.go
+++ b/internal/backends/ruby/ruby.go
@@ -99,12 +99,12 @@ var RubyBackend = api.LanguageBackend{
 
 		body, err := io.ReadAll(resp.Body)
 		if err != nil {
-			util.Die("RubyGems: %s", err)
+			util.DieProtocol("RubyGems: %s", err)
 		}
 
 		var outputStructs []rubygemsInfo
 		if err := json.Unmarshal(body, &outputStructs); err != nil {
-			util.Die("RubyGems response: %s", err)
+			util.DieProtocol("RubyGems response: %s", err)
 		}
 
 		results := []api.PkgInfo{}
@@ -151,12 +151,12 @@ var RubyBackend = api.LanguageBackend{
 
 		body, err := io.ReadAll(resp.Body)
 		if err != nil {
-			util.Die("RubyGems: %s", err)
+			util.DieProtocol("RubyGems: %s", err)
 		}
 
 		var s rubygemsInfo
 		if err := json.Unmarshal(body, &s); err != nil {
-			util.Die("RubyGems response: %s", err)
+			util.DieProtocol("RubyGems response: %s", err)
 		}
 		deps := []string{}
 		for _, group := range s.Dependencies {
@@ -238,7 +238,7 @@ var RubyBackend = api.LanguageBackend{
 		})
 		results := map[api.PkgName]api.PkgSpec{}
 		if err := json.Unmarshal(outputB, &results); err != nil {
-			util.Die("ruby: %s", err)
+			util.DieProtocol("ruby: %s", err)
 		}
 		return results
 	},
@@ -248,7 +248,7 @@ var RubyBackend = api.LanguageBackend{
 		})
 		results := map[api.PkgName]api.PkgVersion{}
 		if err := json.Unmarshal(outputB, &results); err != nil {
-			util.Die("ruby: %s", err)
+			util.DieProtocol("ruby: %s", err)
 		}
 		return results
 	},
@@ -264,7 +264,7 @@ var RubyBackend = api.LanguageBackend{
 		})
 		results := map[string][]api.PkgName{}
 		if err := json.Unmarshal(guessedGems, &results); err != nil {
-			util.Die("ruby: %s", err)
+			util.DieProtocol("ruby: %s", err)
 		}
 		return results, true
 	},

--- a/internal/backends/rust/rust.go
+++ b/internal/backends/rust/rust.go
@@ -153,7 +153,7 @@ func info(name api.PkgName) api.PkgInfo {
 func listSpecfile() map[api.PkgName]api.PkgSpec {
 	contents, err := os.ReadFile("Cargo.toml")
 	if err != nil {
-		util.Die("Cargo.toml: %s", err)
+		util.DieIO("Cargo.toml: %s", err)
 	}
 
 	return listSpecfileWithContents(contents)
@@ -204,7 +204,7 @@ func listSpecfileWithContents(contents []byte) map[api.PkgName]api.PkgSpec {
 func listLockfile() map[api.PkgName]api.PkgVersion {
 	contents, err := os.ReadFile("Cargo.lock")
 	if err != nil {
-		util.Die("Cargo.lock: %s", err)
+		util.DieIO("Cargo.lock: %s", err)
 	}
 
 	return listLockfileWithContents(contents)
@@ -214,7 +214,7 @@ func listLockfileWithContents(contents []byte) map[api.PkgName]api.PkgVersion {
 	var lockfile cargoLock
 	err := toml.Unmarshal(contents, &lockfile)
 	if err != nil {
-		util.Die("Cargo.lock: %s", err)
+		util.DieIO("Cargo.lock: %s", err)
 	}
 
 	packages := make(map[api.PkgName]api.PkgVersion)

--- a/internal/backends/rust/rust.go
+++ b/internal/backends/rust/rust.go
@@ -99,12 +99,12 @@ func search(query string) []api.PkgInfo {
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		util.Die("crates.io: %s", err)
+		util.DieProtocol("crates.io: %s", err)
 	}
 
 	var crateResults crateSearchResults
 	if err := json.Unmarshal(body, &crateResults); err != nil {
-		util.Die("crates.io: %s", err)
+		util.DieProtocol("crates.io: %s", err)
 	}
 
 	var pkgs []api.PkgInfo
@@ -139,12 +139,12 @@ func info(name api.PkgName) api.PkgInfo {
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		util.Die("crates.io: could not read response: %s", err)
+		util.DieProtocol("crates.io: could not read response: %s", err)
 	}
 
 	var crateInfo crateInfoResult
 	if err := json.Unmarshal(body, &crateInfo); err != nil {
-		util.Die("crates.io: %s", err)
+		util.DieProtocol("crates.io: %s", err)
 	}
 
 	return crateInfo.toPkgInfo()
@@ -163,7 +163,7 @@ func listSpecfileWithContents(contents []byte) map[api.PkgName]api.PkgSpec {
 	var specfile cargoToml
 	err := toml.Unmarshal(contents, &specfile)
 	if err != nil {
-		util.Die("Cargo.toml: %s", err)
+		util.DieProtocol("Cargo.toml: %s", err)
 	}
 
 	packages := make(map[api.PkgName]api.PkgSpec)
@@ -191,7 +191,7 @@ func listSpecfileWithContents(contents []byte) map[api.PkgName]api.PkgSpec {
 			}
 
 		default:
-			util.Die("Cargo.toml: unexpected dependency format %q", name)
+			util.DieProtocol("Cargo.toml: unexpected dependency format %q", name)
 		}
 
 		packages[api.PkgName(name)] = spec

--- a/internal/backends/rust/rust.go
+++ b/internal/backends/rust/rust.go
@@ -187,7 +187,7 @@ func listSpecfileWithContents(contents []byte) map[api.PkgName]api.PkgSpec {
 			}
 
 			if !found {
-				util.Die("Cargo.toml: could not determine spec for dependecy %q", name)
+				util.DieConsistency("Cargo.toml: could not determine spec for dependecy %q", name)
 			}
 
 		default:

--- a/internal/backends/rust/rust.go
+++ b/internal/backends/rust/rust.go
@@ -93,7 +93,7 @@ func search(query string) []api.PkgInfo {
 
 	resp, err := api.HttpClient.Get(endpoint + path)
 	if err != nil {
-		util.Die("crates.io: %s", err)
+		util.DieNetwork("crates.io: %s", err)
 	}
 	defer resp.Body.Close()
 
@@ -124,7 +124,7 @@ func info(name api.PkgName) api.PkgInfo {
 
 	resp, err := api.HttpClient.Get(endpoint + path)
 	if err != nil {
-		util.Die("crates.io: %s", err)
+		util.DieNetwork("crates.io: %s", err)
 	}
 	defer resp.Body.Close()
 
@@ -134,7 +134,7 @@ func info(name api.PkgName) api.PkgInfo {
 	case 404:
 		return api.PkgInfo{}
 	default:
-		util.Die("crates.io: HTTP status %d", resp.StatusCode)
+		util.DieNetwork("crates.io: HTTP status %d", resp.StatusCode)
 	}
 
 	body, err := io.ReadAll(resp.Body)

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -21,7 +21,7 @@ func parseOutputFormat(formatStr string) outputFormat {
 	case "json":
 		return outputFormatJSON
 	default:
-		util.Die(`Error: invalid format %#v (must be "table" or "json")`, formatStr)
+		util.DieConsistency(`Error: invalid format %#v (must be "table" or "json")`, formatStr)
 		return 0
 	}
 }

--- a/internal/cli/cmds.go
+++ b/internal/cli/cmds.go
@@ -133,7 +133,7 @@ func runInfo(language string, pkg string, outputFormat outputFormat) {
 	b := backends.GetBackend(context.Background(), language)
 	info := b.Info(api.PkgName(pkg))
 	if info.Name == "" {
-		util.Die("no such package: %s", pkg)
+		util.DieConsistency("no such package: %s", pkg)
 	}
 
 	switch outputFormat {

--- a/internal/nix/nix.go
+++ b/internal/nix/nix.go
@@ -76,7 +76,7 @@ func ReplitNixAddToNixEditorOps(replitNixAdd ReplitNixAdd) []NixEditorOp {
 func RunNixEditorOps(ops []NixEditorOp) {
 	repl_home := os.Getenv("REPL_HOME")
 	if repl_home == "" {
-		util.Die("REPL_HOME was not set")
+		util.DieInitializationError("REPL_HOME was not set")
 	}
 	path := path.Join(repl_home, "replit.nix")
 

--- a/internal/nix/nix.go
+++ b/internal/nix/nix.go
@@ -99,7 +99,7 @@ func RunNixEditorOps(ops []NixEditorOp) {
 	for _, op := range ops {
 		err := encoder.Encode(op)
 		if err != nil {
-			util.Die("unable to turn op into json: %v error: %s", op, err)
+			util.DieProtocol("unable to turn op into json: %v error: %s", op, err)
 		}
 	}
 	err = stdin.Close()

--- a/internal/nix/nix.go
+++ b/internal/nix/nix.go
@@ -83,16 +83,16 @@ func RunNixEditorOps(ops []NixEditorOp) {
 	cmd := exec.Command("nix-editor", "--path", path)
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
-		util.Die("couldn't make stdin pipe to nix-editor")
+		util.DieSubprocess("couldn't make stdin pipe to nix-editor")
 	}
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
-		util.Die("couldn't make stdout pipe to nix-editor")
+		util.DieSubprocess("couldn't make stdout pipe to nix-editor")
 	}
 
 	err = cmd.Start()
 	if err != nil {
-		util.Die("nix-editor error: %s", err)
+		util.DieSubprocess("nix-editor error: %s", err)
 	}
 
 	encoder := json.NewEncoder(stdin)
@@ -104,7 +104,7 @@ func RunNixEditorOps(ops []NixEditorOp) {
 	}
 	err = stdin.Close()
 	if err != nil {
-		util.Die("unable to write to nix-editor")
+		util.DieSubprocess("unable to write to nix-editor")
 	}
 
 	decoder := json.NewDecoder(stdout)
@@ -118,16 +118,16 @@ func RunNixEditorOps(ops []NixEditorOp) {
 			if errors.Is(err, io.EOF) {
 				break
 			}
-			util.Die("unexpected nix-editor output: %s", err)
+			util.DieSubprocess("unexpected nix-editor output: %s", err)
 		}
 		if nixEditorStatus.Status != "success" {
-			util.Die("nix-editor error: %s", nixEditorStatus.Data)
+			util.DieSubprocess("nix-editor error: %s", nixEditorStatus.Data)
 		}
 	}
 	stdout.Close()
 
 	err = cmd.Wait()
 	if err != nil {
-		util.Die("nix-editor error: %s", err)
+		util.DieSubprocess("nix-editor error: %s", err)
 	}
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -48,7 +48,7 @@ func read() {
 		if os.IsNotExist(err) {
 			return
 		}
-		util.Die("%s: %s", filename, err)
+		util.DieIO("%s: %s", filename, err)
 	}
 
 	if len(strings.TrimSpace(string(bytes))) > 0 {
@@ -103,12 +103,12 @@ func Write(ctx context.Context) {
 
 	filename, err := filepath.Abs(filename)
 	if err != nil {
-		util.Die("%s: %s", filename, err)
+		util.DieIO("%s: %s", filename, err)
 	}
 
 	directory, _ := filepath.Split(filename)
 	if err := os.MkdirAll(directory, 0o777); err != nil {
-		util.Die("%s: %s", directory, err)
+		util.DieIO("%s: %s", directory, err)
 	}
 
 	content, err := json.Marshal(st)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -53,7 +53,7 @@ func read() {
 
 	if len(strings.TrimSpace(string(bytes))) > 0 {
 		if err = json.Unmarshal(bytes, st); err != nil {
-			util.Die("%s: %s", filename, err)
+			util.DieProtocol("%s: %s", filename, err)
 		}
 	}
 

--- a/internal/store/util.go
+++ b/internal/store/util.go
@@ -16,7 +16,7 @@ func hashFile(filename string) hash {
 	if os.IsNotExist(err) {
 		return ""
 	} else if err != nil {
-		util.Die("%s: %s", filename, err)
+		util.DieIO("%s: %s", filename, err)
 	}
 	sum := md5.Sum(bytes)
 	return hash(hex.EncodeToString(sum[:]))

--- a/internal/table/table.go
+++ b/internal/table/table.go
@@ -176,18 +176,18 @@ func printOrPage(text string, width int) {
 	}
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
-		util.Die("connecting pipe to pager stdin: %s", err)
+		util.DieSubprocess("connecting pipe to pager stdin: %s", err)
 	}
 
 	if _, err := io.WriteString(stdin, text); err != nil {
-		util.Die("writing to pager: %s", err)
+		util.DieSubprocess("writing to pager: %s", err)
 	}
 	if err := stdin.Close(); err != nil {
-		util.Die("closing pipe to pager stdin: %s", err)
+		util.DieSubprocess("closing pipe to pager stdin: %s", err)
 	}
 
 	if err := cmd.Run(); err != nil {
-		util.Die("running pager: %s", err)
+		util.DieSubprocess("running pager: %s", err)
 	}
 }
 

--- a/internal/util/command.go
+++ b/internal/util/command.go
@@ -29,7 +29,7 @@ func RunCmd(cmd []string) {
 	command.Stdout = os.Stderr
 	command.Stderr = os.Stderr
 	if err := command.Run(); err != nil {
-		Die("%s", err)
+		DieSubprocess("%s", err)
 	}
 }
 
@@ -50,7 +50,7 @@ func GetCmdOutputFallible(cmd []string) ([]byte, error) {
 func GetCmdOutput(cmd []string) []byte {
 	output, err := GetCmdOutputFallible(cmd)
 	if err != nil {
-		Die("%s", err)
+		DieSubprocess("%s", err)
 	}
 	return output
 }

--- a/internal/util/file.go
+++ b/internal/util/file.go
@@ -56,7 +56,7 @@ func AddIngoredPaths(paths []string) {
 func TryWriteAtomic(filename string, contents []byte) {
 	if err1 := atomic.WriteFile(filename, bytes.NewReader(contents)); err1 != nil {
 		if err2 := os.WriteFile(filename, contents, 0o666); err2 != nil {
-			Die("%s: %s; on non-atomic retry: %s", filename, err1, err2)
+			DieIO("%s: %s; on non-atomic retry: %s", filename, err1, err2)
 		}
 	}
 }
@@ -67,7 +67,7 @@ func Exists(filename string) bool {
 	if _, err := os.Stat(filename); os.IsNotExist(err) {
 		return false
 	} else if err != nil {
-		Die("%s: %s", filename, err)
+		DieIO("%s: %s", filename, err)
 		return false
 	} else {
 		return true
@@ -94,7 +94,7 @@ func SearchRecursive(r *regexp.Regexp, patterns []string) [][]string {
 	matches := [][]string{}
 	err := filepath.Walk(".", func(path string, info os.FileInfo, err error) error {
 		if err != nil {
-			Die("%s: %s", path, err)
+			DieIO("%s: %s", path, err)
 		}
 		for _, name := range IgnoredPaths {
 			if filepath.Base(path) == name {
@@ -118,7 +118,7 @@ func SearchRecursive(r *regexp.Regexp, patterns []string) [][]string {
 		if info.Mode().IsRegular() {
 			contentsB, err := os.ReadFile(path)
 			if err != nil {
-				Die("%s: %s", path, err)
+				DieIO("%s: %s", path, err)
 			}
 			contents := string(contentsB)
 
@@ -147,12 +147,12 @@ func DownloadFile(filepath string, url string) {
 
 	out, err := os.Create(filepath)
 	if err != nil {
-		Die("%s: %s", filepath, err)
+		DieIO("%s: %s", filepath, err)
 	}
 	defer out.Close()
 
 	if _, err := io.Copy(out, resp.Body); err != nil {
-		Die("%s: %s", filepath, err)
+		DieIO("%s: %s", filepath, err)
 	}
 }
 
@@ -161,7 +161,7 @@ func DownloadFile(filepath string, url string) {
 // responsible for cleaning up the temporary directory afterwards.
 func TempDir() string {
 	if tempdir, err := os.MkdirTemp("", "upm"); err != nil {
-		Die("%s", err)
+		DieIO("%s", err)
 		return ""
 	} else {
 		return tempdir
@@ -199,7 +199,7 @@ func WriteResource(url string, tempdir string) string {
 	basename := path.Base(url)
 	filename := filepath.Join(tempdir, basename)
 	if err := os.WriteFile(filename, []byte(contents), 0o666); err != nil {
-		Die("%s", err)
+		DieIO("%s", err)
 	}
 	return filename
 }
@@ -212,19 +212,19 @@ func WriteResource(url string, tempdir string) string {
 func ChdirToUPM() {
 	if dir := os.Getenv("UPM_PROJECT"); dir != "" {
 		if err := os.Chdir(dir); err != nil {
-			Die("%s", err)
+			DieIO("%s", err)
 		}
 		return
 	}
 
 	cur, err := os.Getwd()
 	if err != nil {
-		Die("%s", err)
+		DieIO("%s", err)
 	}
 	for {
 		if Exists(filepath.Join(cur, ".upm")) {
 			if err := os.Chdir(cur); err != nil {
-				Die("%s", err)
+				DieIO("%s", err)
 			}
 			return
 		}

--- a/internal/util/file.go
+++ b/internal/util/file.go
@@ -141,7 +141,7 @@ func DownloadFile(filepath string, url string) {
 	ProgressMsg("download " + url)
 	resp, err := http.Get(url)
 	if err != nil {
-		Die("%s: %s", url, err)
+		DieNetwork("%s: %s", url, err)
 	}
 	defer resp.Body.Close()
 

--- a/internal/util/output.go
+++ b/internal/util/output.go
@@ -74,5 +74,5 @@ func Panicf(format string, a ...interface{}) {
 // operation is not implemented. This should be used in language
 // backends that do not implement all of UPM's API.
 func NotImplemented() {
-	Die("not yet implemented")
+	DieUnimplemented("not yet implemented")
 }

--- a/internal/util/output.go
+++ b/internal/util/output.go
@@ -23,11 +23,6 @@ func ProgressMsg(msg string) {
 
 // Die is like fmt.Printf, but writes to stderr, adds a newline, and
 // terminates the process.
-func Die(format string, a ...interface{}) {
-	fmt.Fprintf(os.Stderr, format+"\n", a...)
-	os.Exit(1)
-}
-
 func die(code int, format string, a ...interface{}) {
 	fmt.Fprintf(os.Stderr, format+"\n", a...)
 	os.Exit(code)

--- a/internal/util/output.go
+++ b/internal/util/output.go
@@ -28,6 +28,43 @@ func Die(format string, a ...interface{}) {
 	os.Exit(1)
 }
 
+func die(code int, format string, a ...interface{}) {
+	fmt.Fprintf(os.Stderr, format+"\n", a...)
+	os.Exit(code)
+}
+
+func DieIO(format string, a ...interface{}) {
+	die(10, format, a...)
+}
+
+func DieOverwrite(format string, a ...interface{}) {
+	die(11, format, a...)
+}
+
+func DieNetwork(format string, a ...interface{}) {
+	die(12, format, a...)
+}
+
+func DieProtocol(format string, a ...interface{}) {
+	die(13, format, a...)
+}
+
+func DieConsistency(format string, a ...interface{}) {
+	die(14, format, a...)
+}
+
+func DieInitializationError(format string, a ...interface{}) {
+	die(15, format, a...)
+}
+
+func DieUnimplemented(format string, a ...interface{}) {
+	die(15, format, a...)
+}
+
+func DieSubprocess(format string, a ...interface{}) {
+	die(16, format, a...)
+}
+
 // Panicf is a composition of fmt.Sprintf and panic.
 func Panicf(format string, a ...interface{}) {
 	panic(fmt.Sprintf(format, a...))


### PR DESCRIPTION
A decent first pass of trying to alert on UPM classifications seems to be to classify upm error categories. If one error code spikes, (`DieNetwork`, as an example,) we'll get a useful signal from that.

I didn't give much thought to the actual error codes, simply incrementing the previous code. If we want to do something clever like a HTTP status code `int(c / 100) == 2`-style pattern I'm happy to revisit, though that'll increase cardinality for minimal gain imo.