### PR TITLE
bug/Disable recursion

### DIFF
--- a/internal/backends/python/grab.go
+++ b/internal/backends/python/grab.go
@@ -244,7 +244,7 @@ var internalModules = map[string]bool{
 	"zoneinfo":        true,
 }
 
-func guess(ctx context.Context, python string) (map[string][]api.PkgName, bool) {
+func guess(ctx context.Context) (map[string][]api.PkgName, bool) {
 	span, ctx := tracer.StartSpanFromContext(ctx, "python.grab.guess")
 	defer span.Finish()
 	cwd, err := os.Getwd()

--- a/internal/backends/python/python.go
+++ b/internal/backends/python/python.go
@@ -303,7 +303,7 @@ func makePythonPoetryBackend(python string) api.LanguageBackend {
 			return pkgs
 		},
 		GuessRegexps: pythonGuessRegexps,
-		Guess:        func(ctx context.Context) (map[string][]api.PkgName, bool) { return guess(ctx, python) },
+		Guess:        guess,
 		InstallReplitNixSystemDependencies: func(ctx context.Context, pkgs []api.PkgName) {
 			//nolint:ineffassign,wastedassign,staticcheck
 			span, ctx := tracer.StartSpanFromContext(ctx, "python.InstallReplitNixSystemDependencies")
@@ -469,7 +469,7 @@ func makePythonPipBackend(python string) api.LanguageBackend {
 			return pkgs
 		},
 		GuessRegexps: pythonGuessRegexps,
-		Guess:        func(ctx context.Context) (map[string][]api.PkgName, bool) { return guess(ctx, python) },
+		Guess:        guess,
 		InstallReplitNixSystemDependencies: func(ctx context.Context, pkgs []api.PkgName) {
 			//nolint:ineffassign,wastedassign,staticcheck
 			span, ctx := tracer.StartSpanFromContext(ctx, "python.InstallReplitNixSystemDependencies")

--- a/internal/util/tree-sitter.go
+++ b/internal/util/tree-sitter.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path"
 	"regexp"
+	"strings"
 
 	sitter "github.com/smacker/go-tree-sitter"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
@@ -40,9 +41,16 @@ func GuessWithTreeSitter(ctx context.Context, root string, lang *sitter.Language
 	defer span.Finish()
 	dirFS := os.DirFS(root)
 
-	var visited int
+	var visited int = 0
 	pathsToSearch := []string{}
 	err := fs.WalkDir(dirFS, ".", func(dir string, d fs.DirEntry, err error) error {
+		// Reproduce the previous behavior of https://github.com/replit/upm/pull/202
+		// During integration tests it was determined that we do need to consider a whole
+		// host of ignore patterns, otherwise we run the risk of guessing transitive deps
+		// from the package store.
+		if (dir != "." && d.IsDir()) || strings.Contains(dir, "/") {
+			return fs.SkipDir
+		}
 		dir = path.Join(root, dir)
 		if err != nil {
 			return err

--- a/internal/util/tree-sitter.go
+++ b/internal/util/tree-sitter.go
@@ -41,6 +41,7 @@ func GuessWithTreeSitter(ctx context.Context, root string, lang *sitter.Language
 	defer span.Finish()
 	dirFS := os.DirFS(root)
 
+	forceRecurse := os.Getenv("UPM_FORCE_RECURSE") == "1"
 	var visited int = 0
 	pathsToSearch := []string{}
 	err := fs.WalkDir(dirFS, ".", func(dir string, d fs.DirEntry, err error) error {
@@ -48,7 +49,9 @@ func GuessWithTreeSitter(ctx context.Context, root string, lang *sitter.Language
 		// During integration tests it was determined that we do need to consider a whole
 		// host of ignore patterns, otherwise we run the risk of guessing transitive deps
 		// from the package store.
-		if (dir != "." && d.IsDir()) || strings.Contains(dir, "/") {
+		isDir := dir != "." && d.IsDir()
+		isInDir := strings.Contains(dir, "/")
+		if !forceRecurse && (isDir || isInDir) {
 			return fs.SkipDir
 		}
 		dir = path.Join(root, dir)


### PR DESCRIPTION
Turns out https://github.com/replit/upm/pull/202#discussion_r1439876344 was prescient, without significant pruning we end up discovering transitive dependencies from the package store.

Disable for now, but also permit re-enabling on a case by case basis using `UPM_FORCE_GUESS=1 upm guess`