### PR TITLE
feat/Exclude local packages from guessing

### DIFF
--- a/internal/backends/python/grab.go
+++ b/internal/backends/python/grab.go
@@ -282,7 +282,7 @@ func filterImports(ctx context.Context, foundPkgs map[string]bool) (map[string][
 	//nolint:ineffassign,wastedassign,staticcheck
 	span, ctx := tracer.StartSpanFromContext(ctx, "python.grab.filterImports")
 	defer span.Finish()
-	// filter out internal modules
+	// filter out stdlib/python internal modules
 	for pkg := range foundPkgs {
 		mod := getTopLevelModuleName(pkg)
 		if internalModules[mod] {

--- a/internal/backends/python/grab.go
+++ b/internal/backends/python/grab.go
@@ -284,7 +284,8 @@ func filterImports(ctx context.Context, foundPkgs map[string]bool) (map[string][
 	defer span.Finish()
 	// filter out stdlib/python internal modules
 	for pkg := range foundPkgs {
-		mod := getTopLevelModuleName(pkg)
+		// First path component
+		mod := strings.Split(pkg, ".")[0]
 		if internalModules[mod] {
 			delete(foundPkgs, pkg)
 		}

--- a/internal/backends/python/grab_test.go
+++ b/internal/backends/python/grab_test.go
@@ -3,6 +3,9 @@ package python
 import (
 	"context"
 	"os"
+	"os/exec"
+	"path"
+	"strings"
 	"testing"
 )
 
@@ -53,5 +56,135 @@ import foo #upm package(bar)
 
 	if len(expected) > 0 {
 		t.Errorf("Missing imports %v", expected)
+	}
+}
+
+/* TestLocalModules
+ *
+ * Create a real poetry project in testDir,
+ * execute poetry to lock/install that project,
+ * then execute Python in the project to see the expected string.
+ *
+ * Once that is verified, run doGuess inside the project and confirm
+ * that we only get expected guesses.
+ *
+ * Principally, we do _not_ want to see local packages showing up
+ * in the output!
+ */
+func TestLocalModules(t *testing.T) {
+	expected := "Hello, world!"
+
+	// Every file and its contents for our project.
+	files := map[string]string{
+		"README.md": "stub",
+		"pyproject.toml": `
+[tool.poetry]
+name = "grab-test"
+version = "0.1.0"
+description = ""
+authors = []
+readme = "README.md"
+packages = [{include="foo", from="src"}]
+
+[tool.poetry.dependencies]
+python = "^3.11"
+
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"
+`,
+		"src/foo/__main__.py": `
+import foo.bar.baz
+
+print(foo.bar.baz.blix())
+`,
+		"src/foo/__init__.py":     "",
+		"src/foo/bar/__init__.py": "",
+		"src/foo/bar/baz.py": `
+def blix():
+	return "` + expected + `"
+`,
+		"app.py": ` # TODO(dstewart) Remove this once we re-enable recursion
+import foo.bar.baz
+import flask
+`,
+	}
+
+	// Create the project in a temporary directory
+	testDir := t.TempDir()
+	for fpath, contents := range files {
+		testFile := path.Join(testDir, fpath)
+		err := os.MkdirAll(path.Dir(testFile), 0o755)
+		if err != nil {
+			t.Fatal("unable to create directory", err)
+		}
+		err = os.WriteFile(testFile, []byte(contents), 0o644)
+		if err != nil {
+			t.Fatal("failed to write test file", err)
+		}
+	}
+
+	// Running both of the following tests require we
+	// are in the root of the project directory.
+	lastDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal("unable to get cwd", err)
+	}
+	err = os.Chdir(testDir)
+	if err != nil {
+		t.Fatal("unable to chdir", err)
+	}
+	defer (func() {
+		err := os.Chdir(lastDir)
+		if err != nil {
+		t.Fatal("unable to chdir", err)
+		}
+	})()
+
+	// Sanity test, actually run Python in the environment.
+	cmd := exec.Command("bash", "-c", "poetry lock -n; poetry install; poetry run python -m foo")
+	stdout, err := cmd.Output()
+	if err != nil {
+		t.Fatal("failed to execute python", err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(stdout)), "\n")
+	last := lines[len(lines)-1]
+	if last != expected {
+		t.Errorf("Expected %s to equal %s", last, expected)
+	}
+
+	testPypiMap := func(pkg string) (string, bool) {
+		return strings.Split(pkg, ".")[0], true
+	}
+	// Run guess in the directory.
+	pkgs, _ := doGuess(context.Background(), testPypiMap)
+
+	// Flask is the sentinel, if we do not see it, something
+	// else is wrong.
+	expectedPackages := map[string]bool{"flask": true}
+	for test := range expectedPackages {
+		if _, ok := pkgs[test]; ok {
+			delete(expectedPackages, test)
+		}
+		delete(pkgs, test)
+	}
+
+	if len(expectedPackages) > 0 {
+		expectedPkgs := []string{}
+		for extra := range expectedPackages {
+			expectedPkgs = append(expectedPkgs, extra)
+		}
+
+		t.Fatal("did not guess expected packages: ", strings.Join(expectedPkgs, ", "))
+	}
+
+	if len(pkgs) > 0 {
+		unexpectedPkgs := []string{}
+		for extra := range pkgs {
+			unexpectedPkgs = append(unexpectedPkgs, extra)
+		}
+
+		t.Fatal("guessed extra unexpected packages: ", strings.Join(unexpectedPkgs, ", "))
 	}
 }

--- a/internal/backends/python/modules.go
+++ b/internal/backends/python/modules.go
@@ -6,8 +6,9 @@ import (
 )
 
 type moduleState struct {
-	fileExists  func(path string) bool
-	moduleRoots []string
+	fileExists   func(path string) bool
+	moduleRoots  []string
+	packageRoots map[string]string
 }
 
 // Test to see if `name` is a python module, relative to `directory`
@@ -37,6 +38,15 @@ func (state *moduleState) isModuleLocalToRoot(pkg string, root string) bool {
 // Test to see if a dotted package, `pkg`, is a python module, relative to any project root
 func (state *moduleState) IsLocalModule(pkg string) bool {
 	found := false
+	if state.packageRoots != nil {
+		for localPkg := range state.packageRoots {
+			basePkg := strings.SplitN(pkg, ".", 2)[0]
+			found = localPkg == basePkg
+			if found {
+				return found
+			}
+		}
+	}
 	if state.moduleRoots != nil {
 		for _, root := range state.moduleRoots {
 			found = state.isModuleLocalToRoot(pkg, root)

--- a/internal/backends/python/modules.go
+++ b/internal/backends/python/modules.go
@@ -24,15 +24,13 @@ func (state *moduleState) isModuleComponent(directory string, name string) bool 
 func (state *moduleState) isModuleLocalToRoot(pkg string, root string) bool {
 	components := strings.Split(pkg, ".")
 	dir := root
-	found := true
 	for _, nextComponent := range components {
-		found = state.isModuleComponent(dir, nextComponent)
-		if !found {
-			break
+		if !state.isModuleComponent(dir, nextComponent) {
+			return false
 		}
 		dir = path.Join(dir, nextComponent)
 	}
-	return found
+	return true
 }
 
 // Test to see if a dotted package, `pkg`, is a python module, relative to any project root

--- a/internal/backends/python/modules.go
+++ b/internal/backends/python/modules.go
@@ -1,0 +1,49 @@
+package python
+
+import (
+	"path"
+	"strings"
+)
+
+type moduleState struct {
+	fileExists  func(path string) bool
+	moduleRoots []string
+}
+
+// Test to see if `name` is a python module, relative to `directory`
+func (state *moduleState) isModuleComponent(directory string, name string) bool {
+	result := state.fileExists(path.Join(directory, name+".py"))
+	if !result {
+		result = state.fileExists(path.Join(directory, name, "__init__.py"))
+	}
+	return result
+}
+
+// Test to see if a dotted package, `pkg` (eg: foo.bar.baz) is a python module, relative to `root`
+func (state *moduleState) isModuleLocalToRoot(pkg string, root string) bool {
+	components := strings.Split(pkg, ".")
+	dir := root
+	found := true
+	for _, nextComponent := range components {
+		found = state.isModuleComponent(dir, nextComponent)
+		if !found {
+			break
+		}
+		dir = path.Join(dir, nextComponent)
+	}
+	return found
+}
+
+// Test to see if a dotted package, `pkg`, is a python module, relative to any project root
+func (state *moduleState) IsLocalModule(pkg string) bool {
+	found := false
+	if state.moduleRoots != nil {
+		for _, root := range state.moduleRoots {
+			found = state.isModuleLocalToRoot(pkg, root)
+			if found {
+				return found
+			}
+		}
+	}
+	return found
+}

--- a/internal/backends/python/modules_test.go
+++ b/internal/backends/python/modules_test.go
@@ -23,3 +23,26 @@ func TestBareModules(t *testing.T) {
 		}
 	}
 }
+
+// Presumed executed as python -m app
+func TestPyprojectTrackedProject(t *testing.T) {
+	localFiles := map[string]bool{
+		"app.py":                  true, // Contains `import foo.bar`
+		"src/foo/__init__.py":     true,
+		"src/foo/bar/__init__.py": true,
+	}
+	packageRoots := make(map[string]string)
+	packageRoots["foo"] = "src"
+
+	testState := moduleState{
+		fileExists:   func(path string) bool { return localFiles[path] },
+		moduleRoots:  []string{"."},
+		packageRoots: packageRoots,
+	}
+
+	for _, pkg := range []string{"foo", "foo.bar"} {
+		if !testState.IsLocalModule(pkg) {
+			t.Errorf("%s should be a module", pkg)
+		}
+	}
+}

--- a/internal/backends/python/modules_test.go
+++ b/internal/backends/python/modules_test.go
@@ -1,0 +1,25 @@
+package python
+
+import (
+	"testing"
+)
+
+// Presumed executed as python -m app
+func TestBareModules(t *testing.T) {
+	localFiles := map[string]bool{
+		"app.py":              true, // Contains `import foo.bar`
+		"foo/__init__.py":     true,
+		"foo/bar/__init__.py": true,
+	}
+
+	testState := moduleState{
+		fileExists:  func(path string) bool { return localFiles[path] },
+		moduleRoots: []string{"src", "."},
+	}
+
+	for _, pkg := range []string{"foo", "foo.bar"} {
+		if !testState.IsLocalModule(pkg) {
+			t.Errorf("%s should be a module", pkg)
+		}
+	}
+}

--- a/internal/backends/python/python.go
+++ b/internal/backends/python/python.go
@@ -494,9 +494,17 @@ func makePythonPipBackend(python string) api.LanguageBackend {
 	return b
 }
 
-func listPoetrySpecfile() (map[api.PkgName]api.PkgSpec, error) {
+func readPyproject() (*pyprojectTOML, error) {
 	var cfg pyprojectTOML
 	if _, err := toml.DecodeFile("pyproject.toml", &cfg); err != nil {
+		return nil, err
+	}
+	return &cfg, nil
+}
+
+func listPoetrySpecfile() (map[api.PkgName]api.PkgSpec, error) {
+	cfg, err := readPyproject()
+	if err != nil {
 		return nil, err
 	}
 	pkgs := map[api.PkgName]api.PkgSpec{}

--- a/internal/backends/python/python.go
+++ b/internal/backends/python/python.go
@@ -526,10 +526,6 @@ func listPoetrySpecfile() (map[api.PkgName]api.PkgSpec, error) {
 	return pkgs, nil
 }
 
-func getTopLevelModuleName(fullModname string) string {
-	return strings.Split(fullModname, ".")[0]
-}
-
 // getPython3 returns either "python3" or the value of the UPM_PYTHON3
 // environment variable.
 func getPython3() string {

--- a/internal/backends/python/python.go
+++ b/internal/backends/python/python.go
@@ -1,4 +1,4 @@
-// Package python provides backends for Python 2 and 3 using Poetry.
+// Package python provides backends for Python 2 and 3 using Poetry and pip.
 package python
 
 import (

--- a/internal/backends/python/python.go
+++ b/internal/backends/python/python.go
@@ -46,6 +46,11 @@ type pypiEntryInfo struct {
 	Version       string   `json:"version"`
 }
 
+type pyprojectPackageCfg struct {
+	Include string `json:"include"`
+	From    string `json:"from"`
+}
+
 // pyprojectTOML represents the relevant parts of a pyproject.toml
 // file.
 type pyprojectTOML struct {
@@ -56,6 +61,7 @@ type pyprojectTOML struct {
 			// strings or maps (why?? good lord).
 			Dependencies    map[string]interface{} `json:"dependencies"`
 			DevDependencies map[string]interface{} `json:"dev-dependencies"`
+			Packages        []pyprojectPackageCfg  `json:"packages"`
 		} `json:"poetry"`
 	} `json:"tool"`
 }

--- a/internal/util/output.go
+++ b/internal/util/output.go
@@ -52,12 +52,12 @@ func DieInitializationError(format string, a ...interface{}) {
 	die(15, format, a...)
 }
 
-func DieUnimplemented(format string, a ...interface{}) {
-	die(15, format, a...)
-}
-
 func DieSubprocess(format string, a ...interface{}) {
 	die(16, format, a...)
+}
+
+func DieUnimplemented(format string, a ...interface{}) {
+	die(17, format, a...)
 }
 
 // Panicf is a composition of fmt.Sprintf and panic.


### PR DESCRIPTION
Given either of the following directory structures,

```
.                                │.
├── app.py                       │├── app.py
├── poetry.lock                  │└── foo
├── pyproject.toml               │    ├── __init__.py
└── src                          │    └── bar
    └── foo                      │        ├── __init__.py
        ├── __init__.py          │        └── baz.py
        └── bar                  │
            ├── __init__.py      │3 directories, 4 files
            └── baz.py           │
                                 │
4 directories, 6 files           │
```

the following import directive from `app.py`...
```python
import foo.bar.baz
```

...should not suggest installing any external packages to satisfy `foo`.