### PR TITLE
lock when there isnt a package dir either

### DIFF
--- a/internal/cli/cmds.go
+++ b/internal/cli/cmds.go
@@ -216,7 +216,14 @@ func maybeLock(ctx context.Context, b api.LanguageBackend, forceLock bool) bool 
 		return false
 	}
 
-	if forceLock || !util.Exists(b.Lockfile) || store.HasSpecfileChanged(b) {
+	shouldLock := forceLock || !util.Exists(b.Lockfile) || store.HasSpecfileChanged(b)
+	if !shouldLock {
+		if packageDir := b.GetPackageDir(); packageDir != "" {
+			shouldLock = !util.Exists(packageDir)
+		}
+	}
+
+	if shouldLock {
 		b.Lock(ctx)
 		return true
 	}

--- a/test-suite/Lock_test.go
+++ b/test-suite/Lock_test.go
@@ -30,6 +30,7 @@ func TestLock(t *testing.T) {
 }
 
 func doLock(bt testUtils.BackendT) {
+	// test absence of lock file
 	for _, tmpl := range standardTemplates {
 		template := bt.Backend.Name + "/" + tmpl + "/"
 
@@ -57,4 +58,29 @@ func doLock(bt testUtils.BackendT) {
 			}
 		})
 	}
+
+	// test absence of package dir
+	bt.Subtest(bt.Backend.Name + "/no-package-dir", func(bt testUtils.BackendT) {
+		bt.AddTestFile(bt.Backend.Name+"/many-deps/"+bt.Backend.Specfile, bt.Backend.Specfile)
+
+		specDeps := bt.UpmListSpecFile()
+
+		bt.UpmLock()
+
+		lockDeps := bt.UpmListLockFile()
+
+		for _, specDep := range specDeps {
+			found := false
+			for _, lockDep := range lockDeps {
+				if specDep.Name == lockDep.Name {
+					found = true
+					break
+				}
+			}
+
+			if !found {
+				bt.Fail("expected %s in lock file", specDep.Name)
+			}
+		}
+	})
 }


### PR DESCRIPTION
# Why

There's still some scenarios when `upm lock` doesn't happen. Right now the heuristic is:
1. `--force` flag is passed
2. lockfile doesn't exist
3. specfile has changed

We should also run if the package dir doesn't exist

# What Changed

if the 3 above conditions are all false, then also check to see if `backend.GetPackageDir()` returns a path, and if that path doesn't exist.

# Testing

test suite :)

for manual testing:
1. create a npm package
2. add a dependency and lock (however you choose to do this, doesn't matter)
3. `rm -rdf node_modules` if it exists
4. `upm lock` should recreate the `node_modules` dir