### PR TITLE
add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+Why
+===
+
+_Describe what prompted you to make this change, link relevant resources: tasks, reports, discussions, etc
+
+What changed
+============
+
+_Describe what changed to a level of detail that someone with no context with your PR could be able to review it_
+
+Test plan
+=========
+
+_Describe what you did to test this change to a level of detail that allows your reviewer to test it_


### PR DESCRIPTION
Why
===
* It's easier to fill in a template than come up with it from scratch
* It reminds outside people to provide better context

What changed
===
* Added .github/pull_request_template.md

Test plan
===
* Open a PR and see the template