### PR TITLE
bug/python pip argspec

### DIFF
--- a/internal/backends/python/python.go
+++ b/internal/backends/python/python.go
@@ -102,6 +102,32 @@ func normalizeSpec(spec interface{}) string {
 	return ""
 }
 
+func normalizePackageArgs(args []string) map[api.PkgName]api.PkgCoordinates {
+	pkgs := make(map[api.PkgName]api.PkgCoordinates)
+	for _, arg := range args {
+		var rawName string
+		var name api.PkgName
+		var spec api.PkgSpec
+		if found := matchPackageAndSpec.FindSubmatch([]byte(arg)); len(found) > 0 {
+			rawName = string(found[1])
+			name = api.PkgName(rawName)
+			spec = api.PkgSpec(string(found[2]))
+		} else {
+			split := strings.SplitN(arg, " ", 2)
+			rawName = split[0]
+			name = api.PkgName(rawName)
+			if len(split) > 1 {
+				spec = api.PkgSpec(split[1])
+			}
+		}
+		pkgs[normalizePackageName(name)] = api.PkgCoordinates{
+			Name: rawName,
+			Spec: spec,
+		}
+	}
+	return pkgs
+}
+
 // normalizePackageName implements NormalizePackageName for the Python
 // backends.
 // See https://packaging.python.org/en/latest/specifications/name-normalization/
@@ -228,6 +254,7 @@ func makePythonPoetryBackend(python string) api.LanguageBackend {
 		FilenamePatterns: []string{"*.py"},
 		Quirks: api.QuirksAddRemoveAlsoLocks |
 			api.QuirksAddRemoveAlsoInstalls,
+		NormalizePackageArgs: normalizePackageArgs,
 		NormalizePackageName: normalizePackageName,
 		GetPackageDir: func() string {
 			// Check if we're already inside an activated
@@ -353,6 +380,7 @@ func makePythonPipBackend(python string) api.LanguageBackend {
 		Alias:                "python-python3-pip",
 		FilenamePatterns:     []string{"*.py"},
 		Quirks:               api.QuirksAddRemoveAlsoInstalls | api.QuirksNotReproducible,
+		NormalizePackageArgs: normalizePackageArgs,
 		NormalizePackageName: normalizePackageName,
 		GetPackageDir: func() string {
 			// Check if we're already inside an activated

--- a/internal/backends/python/python.go
+++ b/internal/backends/python/python.go
@@ -104,6 +104,7 @@ func normalizeSpec(spec interface{}) string {
 
 func normalizePackageArgs(args []string) map[api.PkgName]api.PkgCoordinates {
 	pkgs := make(map[api.PkgName]api.PkgCoordinates)
+	versionComponent := regexp.MustCompile(pep440VersionComponent)
 	for _, arg := range args {
 		var rawName string
 		var name api.PkgName
@@ -117,7 +118,17 @@ func normalizePackageArgs(args []string) map[api.PkgName]api.PkgCoordinates {
 			rawName = split[0]
 			name = api.PkgName(rawName)
 			if len(split) > 1 {
-				spec = api.PkgSpec(split[1])
+				specStr := strings.TrimSpace(split[1])
+
+				if specStr != "" {
+					if offset := versionComponent.FindIndex([]byte(spec)); len(offset) == 0 {
+						spec = api.PkgSpec("==" + specStr)
+					} else {
+						spec = api.PkgSpec(specStr)
+					}
+				} else {
+					spec = api.PkgSpec(specStr)
+				}
 			}
 		}
 		pkgs[normalizePackageName(name)] = api.PkgCoordinates{
@@ -420,7 +431,7 @@ func makePythonPipBackend(python string) api.LanguageBackend {
 					pkgs[api.PkgName(name)] = api.PkgSpec(spec)
 				}
 
-				cmd = append(cmd, name+spec)
+				cmd = append(cmd, name+" "+spec)
 			}
 			// Run install
 			util.RunCmd(cmd)

--- a/test-suite/Add_test.go
+++ b/test-suite/Add_test.go
@@ -22,7 +22,7 @@ func TestAdd(t *testing.T) {
 			pkgs = []string{"lodash", "react", "@replit/protocol"}
 
 		case "python3-poetry", "python3-pip":
-			pkgs = []string{"replit-ai", "flask", "pyyaml"}
+			pkgs = []string{"replit-ai", "flask >=2", "pyyaml", "discord-py 2.3.2"}
 
 		default:
 			t.Run(bt.Backend.Name, func(t *testing.T) {

--- a/test-suite/utils/upm.go
+++ b/test-suite/utils/upm.go
@@ -43,11 +43,11 @@ func (bt *BackendT) UpmAdd(pkgs ...string) {
 		bt.Fail("expected more deps in lock file after add (before %d, after %d)", len(beforeSpecDeps), len(afterSpecDeps))
 	}
 
-	for _, pkg := range pkgs {
+	for pkg := range bt.Backend.NormalizePackageArgs(pkgs) {
 		if bt.Backend.QuirksIsReproducible() {
 			found := false
 			for _, dep := range afterLockDeps {
-				if dep.Name == pkg {
+				if bt.Backend.NormalizePackageName(api.PkgName(dep.Name)) == pkg {
 					found = true
 					break
 				}
@@ -59,7 +59,7 @@ func (bt *BackendT) UpmAdd(pkgs ...string) {
 
 		found := false
 		for _, dep := range afterSpecDeps {
-			if dep.Name == pkg {
+			if bt.Backend.NormalizePackageName(api.PkgName(dep.Name)) == pkg {
 				found = true
 				break
 			}


### PR DESCRIPTION
Why
===

When installing packages via pip by way of the `Packages` pane, we interpolate the CLI arg by way of `arg + spec`.

In looking for why this was the case, it turns out that we impose the same argument specifications on all languages, namely `<pkg> <spec>`, which gets confusing in situations like `flask[async]>=2,<3`, where the spec would actually be `[async]>=2,<3`.

<img width="649" alt="image" src="https://github.com/replit/upm/assets/278900/59ef5fa9-1397-455a-989a-bd09aafd8cb6">

Instead, we should defer to language specific parsing semantics where possible, accepting a wider variety of acceptable argspecs, which more closely resemble the args of the underlying commands, to be less confusing.


What changed
============

- Language-specific argument parsing overrides
- Sensible fallback of an empty version constraint to `==` instead of leaving it unconstrained
- For pip, maintain the users' version spec all the way through to writing back to `requirements.txt`, so `upm add flask>=2.3.0` doesn't get turned into `flask===2.3.3` on save.

Test plan
=========

```shell
upm -l python3 --ignored-packages unit_tests --ignored-paths .pythonlibs add 'flask 2'  # Fails, expectedly, since `==2` is not a valid version of flask
upm -l python3 --ignored-packages unit_tests --ignored-paths .pythonlibs add 'flask 2.3.3'
upm -l python3 --ignored-packages unit_tests --ignored-paths .pythonlibs add 'flask'
upm -l python3 --ignored-packages unit_tests --ignored-paths .pythonlibs add 'flask==2.3.3'
upm -l python3 --ignored-packages unit_tests --ignored-paths .pythonlibs add -- 'flask[async]>=2,<3'
```
these all work as expected in both Poetry and Pip