### PR TITLE
Found a typo; fixed it

### DIFF
--- a/internal/nix/python_map.json
+++ b/internal/nix/python_map.json
@@ -124,7 +124,7 @@
   "discordpy":{"deps":["pkgs.ffmpeg-full","pkgs.libopus"]},
   "distorm3":{"deps":["pkgs.yasm"]},
   "django-cacheops":{"deps":["pkgs.nettools"]},
-  "django-health-check":{"deps":["pkgs.gitFulll"]},
+  "django-health-check":{"deps":["pkgs.gitFull"]},
   "django-hijack":{"deps":["pkgs.gettext","pkgs.nodejs"]},
   "django-js-reverse":{"deps":["pkgs.nodejs"]},
   "django-postgresql-netfields":{"deps":["pkgs.postgresql"]},


### PR DESCRIPTION
Why
===

Tried loading all python sys deps into replit.nix, this one failed due to typo. Fixed it.