### PR TITLE
[chore] Avoid running poetry at all for env detection in a repl

### DIFF
--- a/internal/backends/python/python.go
+++ b/internal/backends/python/python.go
@@ -283,6 +283,13 @@ func makePythonPoetryBackend(python string) api.LanguageBackend {
 				return venv
 			}
 
+			// Terminate early if we're running inside a repl.
+			// This will suppress the following poetry commands
+			// from showing up in the Packager pane.
+			if os.Getenv("REPL_HOME") != "" {
+				return ""
+			}
+
 			outputB, err := util.GetCmdOutputFallible([]string{
 				"poetry", "env", "list", "--full-path",
 			})


### PR DESCRIPTION
Why
===

Terminate early if we're running inside a repl.

This will suppress the following poetry commands from showing up in the Packager pane.

What changed
============

Switch env detection based on whether `$REPL_HOME` is defined

Test plan
=========

Clear the `poetry.lock` in order to re-trigger a lock on `Run`, verify that the `poetry env list --full-path` command does not show up in the packager pane every time on `Run`, as it alarms users.
