### PR TITLE
[chore] Acknowledge python2 deprecation, introduce pip

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ machine-parseable specfile and lockfile listing.
 
 |                       | core | index | guess |
 |-----------------------|------|-------|-------|
+| python-python3-pip    | yes  | yes   | yes   |
 | python-python3-poetry | yes  | yes   | yes   |
-| python-python2-poetry | yes  | yes   | yes   |
 | nodejs-yarn           | yes  | yes   | yes   |
 | nodejs-pnpm           | yes  | yes   | yes   |
 | nodejs-npm            | yes  | yes   | yes   |


### PR DESCRIPTION
Why
===

It seems as though the README needed some TLC, address that.

What changed
============

python2 is no longer supported, pip is.

Test plan
=========

_Describe what you did to test this change to a level of detail that allows your reviewer to test it_
