### PR TITLE
chore/Scrutinize pyproject for backends

### DIFF
--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -172,6 +172,9 @@ type LanguageBackend struct {
 	// This field is mandatory.
 	Specfile string
 
+	// An optional function to analyze the specfile to determine compatibility
+	IsSpecfileCompatible func(fullPath string) (bool, error)
+
 	// The filename of the lockfile, e.g. "poetry.lock" for
 	// Poetry.
 	Lockfile string

--- a/internal/backends/backends.go
+++ b/internal/backends/backends.go
@@ -101,12 +101,33 @@ func GetBackend(ctx context.Context, language string) api.LanguageBackend {
 	for _, b := range backends {
 		if util.Exists(b.Specfile) &&
 			util.Exists(b.Lockfile) {
+			if b.IsSpecfileCompatible != nil {
+				isValid, err := b.IsSpecfileCompatible(b.Specfile)
+				if err != nil {
+					panic(err)
+				}
+				if !isValid {
+					continue
+				}
+			}
 			return b
 		}
 	}
 	for _, b := range backends {
-		if util.Exists(b.Specfile) ||
-			util.Exists(b.Lockfile) {
+		if util.Exists(b.Specfile) {
+			if b.IsSpecfileCompatible != nil {
+				isValid, err := b.IsSpecfileCompatible(b.Specfile)
+				if err != nil {
+					panic(err)
+				}
+				if !isValid {
+					continue
+				}
+			}
+
+			return b
+		}
+		if util.Exists(b.Lockfile) {
 			return b
 		}
 	}


### PR DESCRIPTION
Why
===

In cases where users are using `pyproject.toml` for more than just Poetry, we should permit pip + pyproject to coexist.

What changed
============

- Introduced an optional `IsSpecfileCompatible ` to analyze the contents of a specfile to confirm compatibility. Currently exclusively for `poetry`, but this could extend to `package.json` as well

Test plan
=========

```
HD73VL2GVX:pyprpip dstewart$ cat pyproject.toml
[build-system]
requires = ["setuptools"]
build-backend = "setuptools.build_meta"

HD73VL2GVX:pyprpip dstewart$ upm lock
could not autodetect a language for your project

HD73VL2GVX:pyprpip dstewart$ touch requirements.txt

HD73VL2GVX:pyprpip dstewart$ upm lock
--> pip install -r requirements.txt
...
```
