### PR TITLE
[bug] If packageDir does not exist, run Install

### DIFF
--- a/internal/backends/python/python.go
+++ b/internal/backends/python/python.go
@@ -429,7 +429,7 @@ func makePythonPipBackend(python string) api.LanguageBackend {
 
 			if outputB, err := util.GetCmdOutputFallible([]string{
 				"python",
-				"-c", "import site; print(site.USER_SITE)",
+				"-c", "import site; print(site.USER_BASE)",
 			}); err == nil {
 				return string(outputB)
 			}

--- a/internal/backends/python/python.go
+++ b/internal/backends/python/python.go
@@ -284,6 +284,11 @@ func makePythonPoetryBackend(python string) api.LanguageBackend {
 				return venv
 			}
 
+			// Take PYTHONUSERBASE into consideration, if set
+			if userbase := os.Getenv("PYTHONUSERBASE"); userbase != "" {
+				return userbase
+			}
+
 			// Terminate early if we're running inside a repl.
 			// This will suppress the following poetry commands
 			// from showing up in the Packager pane.
@@ -415,6 +420,11 @@ func makePythonPipBackend(python string) api.LanguageBackend {
 			// virtualenv. If so, just use it.
 			if venv := os.Getenv("VIRTUAL_ENV"); venv != "" {
 				return venv
+			}
+
+			// Take PYTHONUSERBASE into consideration, if set
+			if userbase := os.Getenv("PYTHONUSERBASE"); userbase != "" {
+				return userbase
 			}
 
 			if outputB, err := util.GetCmdOutputFallible([]string{

--- a/internal/cli/cmds.go
+++ b/internal/cli/cmds.go
@@ -247,7 +247,11 @@ func maybeInstall(ctx context.Context, b api.LanguageBackend, forceInstall bool)
 		if !util.Exists(b.Specfile) {
 			return
 		}
-		if forceInstall || store.HasSpecfileChanged(b) {
+		var needsPackageDir bool
+		if packageDir := b.GetPackageDir(); packageDir != "" {
+			needsPackageDir = !util.Exists(packageDir)
+		}
+		if forceInstall || store.HasSpecfileChanged(b) || needsPackageDir {
 			b.Install(ctx)
 		}
 	}


### PR DESCRIPTION
Why
===

During testing, `rm -rf .pythonlibs` followed by a `Run` skips package install completely:

Turns out this is because we don't verify the package directory actually exists
```shell
~/2024-02-15-venv-test$ upm show-package-dir
/home/runner/2024-02-15-venv-test/.pythonlibs
~/2024-02-15-venv-test$ du -sh $(upm show-package-dir)
du: cannot access '/home/runner/2024-02-15-venv-test/.pythonlibs': No such file or directory
```

What changed
============

- If the package directory isn't present, ignore the cache and run `install`.

Test plan
=========
