### PR TITLE
[bug] Only dereference into [tool.poetry] if defined

### DIFF
--- a/internal/backends/python/grab.go
+++ b/internal/backends/python/grab.go
@@ -307,7 +307,7 @@ func filterImports(ctx context.Context, foundPkgs map[string]bool, testPypiMap f
 	moduleRoots := []string{"."}
 	packageRoots := make(map[string]string)
 	pyproject, _ := readPyproject()
-	if pyproject != nil {
+	if pyproject != nil && pyproject.Tool.Poetry != nil {
 		for _, pkgCfg := range pyproject.Tool.Poetry.Packages {
 			pkgRoot := pkgCfg.Include
 			from := "."


### PR DESCRIPTION
Why
===

- Unintentional nil-deference introduced by #234 

What changed
============

- Source directories should be offered by the backend, instead of leaking implementation details into other parts of the codebase. For now, just fix the bug.

Test plan
=========

`pyproject.toml` with no `[tool.poetry]` should still work with `upm guess`
