### PR TITLE
bug/better tensorflow recommendations

### DIFF
--- a/internal/backends/python/pypi_map.override.go
+++ b/internal/backends/python/pypi_map.override.go
@@ -1,18 +1,22 @@
 package python
 
+var tf_variants = [...]string{"tensorflow-cpu", "tensorflow-cpu-aws", "tensorflow-gpu", "tensorflow-intel", "tf-nightly", "tf-nightly-cpu", "tf-nightly-cpu-aws", "tf-nightly-gpu", "tf-nightly-intel"}
+
 /*
 Manual module -> package mapping overrides
 */
 var moduleToPypiPackageOverride = map[string][]string{
-	"grpc_status":  {"grpcio-status"},           // 2nd most popular
-	"nvd3":         {"python-nvd3"},             // not popular enough 6th in popularity
-	"requirements": {"requirements-parser"},     // popular rlbot depends on it, but doesn't supply requires_dist
-	"base62":       {"pybase62"},                // it was overridden by base-62 which wins due to name match but is less popular by far
-	"faiss":        {"faiss-cpu"},               // faiss is offered as precompiled wheels, faiss-cpu and faiss-gpu.
-	"graphics":     {"graphics.py"},             // this package is popular, but the module doesn't match the package name https://anh.cs.luc.edu/python/hands-on/3.1/handsonHtml/graphics.html#a-graphics-introduction
-	"replit.ai":    {"replit-ai"},               // Replit's AI package
-	"glm":          {"PyGLM", "glm"},            // Both of these packages are valid, but PyGLM is a library, glm is an executable.
-	"ldclient":     {"ldclient-py", "ldclient"}, // LaunchDarkly client
+	"grpc_status":          {"grpcio-status"},                                 // 2nd most popular
+	"nvd3":                 {"python-nvd3"},                                   // not popular enough 6th in popularity
+	"requirements":         {"requirements-parser"},                           // popular rlbot depends on it, but doesn't supply requires_dist
+	"base62":               {"pybase62"},                                      // it was overridden by base-62 which wins due to name match but is less popular by far
+	"faiss":                {"faiss-cpu"},                                     // faiss is offered as precompiled wheels, faiss-cpu and faiss-gpu.
+	"graphics":             {"graphics.py"},                                   // this package is popular, but the module doesn't match the package name https://anh.cs.luc.edu/python/hands-on/3.1/handsonHtml/graphics.html#a-graphics-introduction
+	"replit.ai":            {"replit-ai"},                                     // Replit's AI package
+	"glm":                  {"PyGLM", "glm"},                                  // Both of these packages are valid, but PyGLM is a library, glm is an executable.
+	"ldclient":             {"ldclient-py", "ldclient"},                       // LaunchDarkly client
+	"tensorflow":           append([]string{"tensorflow"}, tf_variants[:]...), // Avoid suggesting conflicting tensorflow builds
+	"tensorflow-federated": {"tensorflow-federated", "tensorflow-federated-nightly"}, // Avoid suggesting conflicting tensorflow-federated packages
 }
 
 /* Proxy packages

--- a/internal/backends/python/pypi_map.override.go
+++ b/internal/backends/python/pypi_map.override.go
@@ -6,17 +6,18 @@ var tf_variants = [...]string{"tensorflow-cpu", "tensorflow-cpu-aws", "tensorflo
 Manual module -> package mapping overrides
 */
 var moduleToPypiPackageOverride = map[string][]string{
-	"grpc_status":          {"grpcio-status"},                                 // 2nd most popular
-	"nvd3":                 {"python-nvd3"},                                   // not popular enough 6th in popularity
-	"requirements":         {"requirements-parser"},                           // popular rlbot depends on it, but doesn't supply requires_dist
-	"base62":               {"pybase62"},                                      // it was overridden by base-62 which wins due to name match but is less popular by far
-	"faiss":                {"faiss-cpu"},                                     // faiss is offered as precompiled wheels, faiss-cpu and faiss-gpu.
-	"graphics":             {"graphics.py"},                                   // this package is popular, but the module doesn't match the package name https://anh.cs.luc.edu/python/hands-on/3.1/handsonHtml/graphics.html#a-graphics-introduction
-	"replit.ai":            {"replit-ai"},                                     // Replit's AI package
-	"glm":                  {"PyGLM", "glm"},                                  // Both of these packages are valid, but PyGLM is a library, glm is an executable.
-	"ldclient":             {"ldclient-py", "ldclient"},                       // LaunchDarkly client
-	"tensorflow":           append([]string{"tensorflow"}, tf_variants[:]...), // Avoid suggesting conflicting tensorflow builds
+	"grpc_status":          {"grpcio-status"},                                        // 2nd most popular
+	"nvd3":                 {"python-nvd3"},                                          // not popular enough 6th in popularity
+	"requirements":         {"requirements-parser"},                                  // popular rlbot depends on it, but doesn't supply requires_dist
+	"base62":               {"pybase62"},                                             // it was overridden by base-62 which wins due to name match but is less popular by far
+	"faiss":                {"faiss-cpu"},                                            // faiss is offered as precompiled wheels, faiss-cpu and faiss-gpu.
+	"graphics":             {"graphics.py"},                                          // this package is popular, but the module doesn't match the package name https://anh.cs.luc.edu/python/hands-on/3.1/handsonHtml/graphics.html#a-graphics-introduction
+	"replit.ai":            {"replit-ai"},                                            // Replit's AI package
+	"glm":                  {"PyGLM", "glm"},                                         // Both of these packages are valid, but PyGLM is a library, glm is an executable.
+	"ldclient":             {"ldclient-py", "ldclient"},                              // LaunchDarkly client
+	"tensorflow":           append([]string{"tensorflow"}, tf_variants[:]...),        // Avoid suggesting conflicting tensorflow builds
 	"tensorflow-federated": {"tensorflow-federated", "tensorflow-federated-nightly"}, // Avoid suggesting conflicting tensorflow-federated packages
+	"tensorflow1":          {"tensorflow"},                                           // Avoid confusion.
 }
 
 /* Proxy packages

--- a/internal/backends/python/python.go
+++ b/internal/backends/python/python.go
@@ -243,6 +243,7 @@ func add(ctx context.Context, pkgs map[api.PkgName]api.PkgSpec, projectName stri
 }
 
 func searchPypi(query string) []api.PkgInfo {
+	query = strings.ToLower(query)
 	var original api.PkgName
 	if renamed, found := moduleToPypiPackageOverride[query]; found {
 		original = normalizePackageName(api.PkgName(query))

--- a/internal/backends/python/python.go
+++ b/internal/backends/python/python.go
@@ -245,9 +245,7 @@ func add(ctx context.Context, pkgs map[api.PkgName]api.PkgSpec, projectName stri
 func searchPypi(query string) []api.PkgInfo {
 	// Normalize query before looking it up in the overide map
 	query = string(normalizePackageName(api.PkgName(query)))
-	var original api.PkgName
 	if renamed, found := moduleToPypiPackageOverride[query]; found {
-		original = normalizePackageName(api.PkgName(query))
 		query = renamed[0]
 	}
 	results, err := SearchPypi(query)
@@ -257,9 +255,17 @@ func searchPypi(query string) []api.PkgInfo {
 	// Elide package override from results
 	filtered := []api.PkgInfo{}
 	for _, info := range results {
-		if normalizePackageName(api.PkgName(info.Name)) != original {
-			filtered = append(filtered, info)
+		lowered := string(normalizePackageName(api.PkgName(info.Name)))
+		if rename, ok := moduleToPypiPackageOverride[lowered]; ok {
+			// If rename[0] == lowered, we are noconflicting a package
+			// If they are different, we are overriding that package,
+			// so the query'd package should not be included in the results
+			// set.
+			if rename[0] != lowered {
+				continue
+			}
 		}
+		filtered = append(filtered, info)
 	}
 	return filtered
 }

--- a/internal/backends/python/python.go
+++ b/internal/backends/python/python.go
@@ -243,7 +243,8 @@ func add(ctx context.Context, pkgs map[api.PkgName]api.PkgSpec, projectName stri
 }
 
 func searchPypi(query string) []api.PkgInfo {
-	query = strings.ToLower(query)
+	// Normalize query before looking it up in the overide map
+	query = string(normalizePackageName(api.PkgName(query)))
 	var original api.PkgName
 	if renamed, found := moduleToPypiPackageOverride[query]; found {
 		original = normalizePackageName(api.PkgName(query))


### PR DESCRIPTION
Why
===

Follow-up to #238, tweak `guess` and search results to favor `tensorflow` instead of auxiliary packages. If users want those packages, they're more than welcome to install them directly, but upm should not suggest them.

What changed
============

- More aggressive filtering of search results
- Map `tensorflow-${arch}` and `tf-nightly-${arch}` to the common `tensorflow`

Test plan
=========

```
$ upm search Tensorflow  # tensorflow should be on the top
$ upm search Tensorflow1 # tensorflow should be on the top

$ echo 'import tensorflow' > main.py
$ upm guess # tensorflow
```
