### PR TITLE
feat/python guess inside ifstat

### DIFF
--- a/internal/backends/python/grab.go
+++ b/internal/backends/python/grab.go
@@ -19,7 +19,23 @@ var importsQuery = `
               name: (dotted_name) @import)])
 
    (import_from_statement
-     module_name: (dotted_name) @import)]
+     module_name: (dotted_name) @import)
+
+    (if_statement
+      condition: (_)
+      consequence: (block
+        [
+          (import_statement
+            name: [(dotted_name) @import
+               (aliased_import
+                 name: (dotted_name) @import)]
+          )
+          (import_from_statement
+            module_name: (dotted_name) @import)
+        ]
+      )
+    )
+  ]
 
   .
 

--- a/internal/backends/python/grab.go
+++ b/internal/backends/python/grab.go
@@ -13,54 +13,33 @@ import (
 
 var importsQuery = `
 (module
-  [
-    (import_statement
-      name: [
-        (dotted_name) @import
-        (aliased_import
-          name: (dotted_name) @import
-        )
-      ]
-    )
-
-    (import_from_statement
-      module_name: (dotted_name) @import
-    )
-
-    (if_statement [
-      (block [
-        (import_statement
-          name: [
-            (dotted_name) @import
+  [(import_statement
+     name: [(dotted_name) @import
             (aliased_import
-              name: (dotted_name) @import
-            )
-          ]
-        )
-        (import_from_statement
-        module_name: (dotted_name) @import)
-      ])
-      (_
-        (block [
-          (import_statement
-            name: [
-              (dotted_name) @import
-              (aliased_import
-                name: (dotted_name) @import)
-            ]
-          )
-          (import_from_statement
-            module_name: (dotted_name) @import
-          )
-        ])
-      )
-    ])
-  ]
+              name: (dotted_name) @import)])
+   (import_from_statement
+     module_name: (dotted_name) @import)
+   (if_statement
+     [(block
+        [(import_statement
+           name:
+            [(dotted_name) @import
+             (aliased_import
+               name: (dotted_name) @import)])
+         (import_from_statement
+           module_name: (dotted_name) @import)])
+      (_ (block
+           [(import_statement
+              name:
+               [(dotted_name) @import
+                (aliased_import
+                  name: (dotted_name) @import)])
+            (import_from_statement
+              module_name: (dotted_name) @import)]))])]
 
   .
 
-  (comment)? @pragma
-)
+  (comment)? @pragma)
 `
 
 var pyPathSegmentPatterns = []string{"*.py"}

--- a/internal/backends/python/grab.go
+++ b/internal/backends/python/grab.go
@@ -13,43 +13,54 @@ import (
 
 var importsQuery = `
 (module
-  [(import_statement
-     name: [(dotted_name) @import
-            (aliased_import
-              name: (dotted_name) @import)])
-
-   (import_from_statement
-     module_name: (dotted_name) @import)
-
-    (if_statement
-      [
-      (block [
-          (import_statement
-            name: [(dotted_name) @import
-               (aliased_import
-                 name: (dotted_name) @import)]
-          )
-          (import_from_statement
-            module_name: (dotted_name) @import)
-        ]
-      )
-      (_ (block [
-          (import_statement
-            name: [(dotted_name) @import
-               (aliased_import
-                 name: (dotted_name) @import)]
-          )
-          (import_from_statement
-            module_name: (dotted_name) @import)
-        ]
-      ) )
+  [
+    (import_statement
+      name: [
+        (dotted_name) @import
+        (aliased_import
+          name: (dotted_name) @import
+        )
       ]
     )
+
+    (import_from_statement
+      module_name: (dotted_name) @import
+    )
+
+    (if_statement [
+      (block [
+        (import_statement
+          name: [
+            (dotted_name) @import
+            (aliased_import
+              name: (dotted_name) @import
+            )
+          ]
+        )
+        (import_from_statement
+        module_name: (dotted_name) @import)
+      ])
+      (_
+        (block [
+          (import_statement
+            name: [
+              (dotted_name) @import
+              (aliased_import
+                name: (dotted_name) @import)
+            ]
+          )
+          (import_from_statement
+            module_name: (dotted_name) @import
+          )
+        ])
+      )
+    ])
   ]
 
   .
 
-  (comment)? @pragma)
+  (comment)? @pragma
+)
 `
 
 var pyPathSegmentPatterns = []string{"*.py"}

--- a/internal/backends/python/grab.go
+++ b/internal/backends/python/grab.go
@@ -22,9 +22,8 @@ var importsQuery = `
      module_name: (dotted_name) @import)
 
     (if_statement
-      condition: (_)
-      consequence: (block
-        [
+      [
+      (block [
           (import_statement
             name: [(dotted_name) @import
                (aliased_import
@@ -34,6 +33,17 @@ var importsQuery = `
             module_name: (dotted_name) @import)
         ]
       )
+      (_ (block [
+          (import_statement
+            name: [(dotted_name) @import
+               (aliased_import
+                 name: (dotted_name) @import)]
+          )
+          (import_from_statement
+            module_name: (dotted_name) @import)
+        ]
+      ) )
+      ]
     )
   ]
 

--- a/internal/backends/python/grab_test.go
+++ b/internal/backends/python/grab_test.go
@@ -20,6 +20,7 @@ func TestParseFile(t *testing.T) {
 		"replit":    true,
 		"replit.ai": true,
 		"bar":       true,
+		"baz":       true,
 	}
 
 	content := `
@@ -30,6 +31,9 @@ from Flask import Flask
 import replit
 import replit.ai
 import foo #upm package(bar)
+
+if True:
+    import baz
 `
 
 	testDir := t.TempDir()

--- a/internal/backends/python/grab_test.go
+++ b/internal/backends/python/grab_test.go
@@ -20,7 +20,10 @@ func TestParseFile(t *testing.T) {
 		"replit":    true,
 		"replit.ai": true,
 		"bar":       true,
-		"baz":       true,
+		"cond1":     true,
+		"cond2":     true,
+		"cond3":     true,
+		"cond4":     true,
 	}
 
 	content := `
@@ -32,8 +35,14 @@ import replit
 import replit.ai
 import foo #upm package(bar)
 
-if True:
-    import baz
+if False:
+    import cond1
+elif True:
+    import cond2
+elif True:
+    import cond3
+else:
+    import cond4
 `
 
 	testDir := t.TempDir()

--- a/internal/backends/python/grab_test.go
+++ b/internal/backends/python/grab_test.go
@@ -1,7 +1,9 @@
 package python
 
 import (
+	"bytes"
 	"context"
+	"fmt"
 	"os"
 	"os/exec"
 	"path"
@@ -144,8 +146,13 @@ import flask
 
 	// Sanity test, actually run Python in the environment.
 	cmd := exec.Command("bash", "-c", "poetry lock -n; poetry install; poetry run python -m foo")
+
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
 	stdout, err := cmd.Output()
 	if err != nil {
+
+		fmt.Println("stderr:", stderr.String())
 		t.Fatal("failed to execute python", err)
 	}
 	lines := strings.Split(strings.TrimSpace(string(stdout)), "\n")

--- a/replit.nix
+++ b/replit.nix
@@ -14,8 +14,8 @@
     pkgs.nodejs-18_x
     pkgs.yarn
     pkgs.nodePackages.pnpm
-    pkgs.python310Full
-    pkgs.python310Packages.pip
+    pkgs.python311Full
+    pkgs.python311Packages.pip
     pkgs.poetry
     pkgs.R
     pkgs.ruby


### PR DESCRIPTION
Why
===

It's reasonably common for Python libraries to include gate imports behind `if`, `def`, and `try` statements. Let's try adding `if`/`elif`/`else` and see whether this is even a direction we want to proceed with.

What changed
============

Altered query to reflect the `if_statement` structure. Extended test to cover this new case.

Test plan
=========

See whether imports gated behind `if` statements are caught by `upm guess`