### PR TITLE
feat/Filter dep groups out of guess

### DIFF
--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -297,7 +297,7 @@ type LanguageBackend struct {
 	// specfile is guaranteed to exist already.
 	//
 	// This field is mandatory.
-	ListSpecfile func() map[PkgName]PkgSpec
+	ListSpecfile func(mergeAllGroups bool) map[PkgName]PkgSpec
 
 	// List the packages in the lockfile. Names should be returned
 	// in a format suitable for the Add method. The lockfile is

--- a/internal/backends/dart/dart.go
+++ b/internal/backends/dart/dart.go
@@ -63,7 +63,7 @@ type dartPubspecYaml struct {
 }
 
 // dartListPubspecYaml lists all deps in a pubspec.yaml file
-func dartListPubspecYaml() map[api.PkgName]api.PkgSpec {
+func dartListPubspecYaml(mergeAllGroups bool) map[api.PkgName]api.PkgSpec {
 	specs := readSpecFile()
 
 	pkgs := map[api.PkgName]api.PkgSpec{}

--- a/internal/backends/dotnet/project_files.go
+++ b/internal/backends/dotnet/project_files.go
@@ -45,7 +45,7 @@ func findSpecFile() string {
 }
 
 // loads the details of the project spec file
-func listSpecfile() map[api.PkgName]api.PkgSpec {
+func listSpecfile(mergeAllGroups bool) map[api.PkgName]api.PkgSpec {
 	var pkgs map[api.PkgName]api.PkgSpec
 	projectFile := findSpecFile()
 	specReader, err := os.Open(projectFile)

--- a/internal/backends/elisp/elisp.go
+++ b/internal/backends/elisp/elisp.go
@@ -158,7 +158,7 @@ var ElispBackend = api.LanguageBackend{
 		util.ProgressMsg("write packages.txt")
 		util.TryWriteAtomic("packages.txt", outputB)
 	},
-	ListSpecfile: func() map[api.PkgName]api.PkgSpec {
+	ListSpecfile: func(mergeAllGroups bool) map[api.PkgName]api.PkgSpec {
 		outputB := util.GetCmdOutput(
 			[]string{"cask", "eval", util.GetResource(
 				"/elisp/cask-list-specfile.el",

--- a/internal/backends/java/java.go
+++ b/internal/backends/java/java.go
@@ -243,7 +243,7 @@ func removePackages(ctx context.Context, pkgs map[api.PkgName]bool) {
 	os.RemoveAll("target/dependency")
 }
 
-func listSpecfile() map[api.PkgName]api.PkgSpec {
+func listSpecfile(mergeAllGroups bool) map[api.PkgName]api.PkgSpec {
 	project := readProjectOrMakeEmpty(pomdotxml)
 	pkgs := map[api.PkgName]api.PkgSpec{}
 	for _, dependency := range project.Dependencies {

--- a/internal/backends/nodejs/nodejs.go
+++ b/internal/backends/nodejs/nodejs.go
@@ -339,7 +339,7 @@ func nodejsInfo(name api.PkgName) api.PkgInfo {
 
 // nodejsListSpecfile implements ListSpecfile for nodejs-yarn, nodejs-pnpm and
 // nodejs-npm.
-func nodejsListSpecfile() map[api.PkgName]api.PkgSpec {
+func nodejsListSpecfile(mergeAllGroups bool) map[api.PkgName]api.PkgSpec {
 	contentsB, err := os.ReadFile("package.json")
 	if err != nil {
 		util.DieIO("package.json: %s", err)

--- a/internal/backends/php/php.go
+++ b/internal/backends/php/php.go
@@ -173,7 +173,7 @@ func parseInfo(body []byte, packageName api.PkgName) (api.PkgInfo, error) {
 	}, nil
 }
 
-func listSpecfile() map[api.PkgName]api.PkgSpec {
+func listSpecfile(mergeAllGroups bool) map[api.PkgName]api.PkgSpec {
 	contents, err := os.ReadFile("composer.json")
 
 	if err != nil {

--- a/internal/backends/python/python.go
+++ b/internal/backends/python/python.go
@@ -51,6 +51,10 @@ type pyprojectPackageCfg struct {
 	From    string `json:"from"`
 }
 
+type pyprojectTOMLGroup struct {
+	Dependencies map[string]interface{} `json:"dependencies"`
+}
+
 // pyprojectTOML represents the relevant parts of a pyproject.toml
 // file.
 type pyprojectTOML struct {
@@ -59,9 +63,10 @@ type pyprojectTOML struct {
 			Name string `json:"name"`
 			// interface{} because they can be either
 			// strings or maps (why?? good lord).
-			Dependencies    map[string]interface{} `json:"dependencies"`
-			DevDependencies map[string]interface{} `json:"dev-dependencies"`
-			Packages        []pyprojectPackageCfg  `json:"packages"`
+			Dependencies    map[string]interface{}        `json:"dependencies"`
+			DevDependencies map[string]interface{}        `json:"dev-dependencies"`
+			Packages        []pyprojectPackageCfg         `json:"packages"`
+			Group           map[string]pyprojectTOMLGroup `json:"group"`
 		} `json:"poetry"`
 	} `json:"tool"`
 }

--- a/internal/backends/python/python.go
+++ b/internal/backends/python/python.go
@@ -360,8 +360,8 @@ func makePythonPoetryBackend(python string) api.LanguageBackend {
 			// <https://github.com/sdispater/poetry/issues/648>.
 			util.RunCmd([]string{"poetry", "install"})
 		},
-		ListSpecfile: func() map[api.PkgName]api.PkgSpec {
-			pkgs, err := listPoetrySpecfile(false)
+		ListSpecfile: func(mergeAllGroups bool) map[api.PkgName]api.PkgSpec {
+			pkgs, err := listPoetrySpecfile(mergeAllGroups)
 			if err != nil {
 				util.DieIO("%s", err.Error())
 			}
@@ -567,7 +567,7 @@ func makePythonPipBackend(python string) api.LanguageBackend {
 
 			util.RunCmd([]string{"pip", "install", "-r", "requirements.txt"})
 		},
-		ListSpecfile: func() map[api.PkgName]api.PkgSpec {
+		ListSpecfile: func(mergeAllGroups bool) map[api.PkgName]api.PkgSpec {
 			flags, pkgs, err := ListRequirementsTxt("requirements.txt")
 			if err != nil {
 				util.DieIO("%s", err.Error())

--- a/internal/backends/rlang/rlang.go
+++ b/internal/backends/rlang/rlang.go
@@ -161,7 +161,7 @@ var RlangBackend = api.LanguageBackend{
 			}
 		}
 	},
-	ListSpecfile: func() map[api.PkgName]api.PkgSpec {
+	ListSpecfile: func(mergeAllGroups bool) map[api.PkgName]api.PkgSpec {
 		pkgs := map[api.PkgName]api.PkgSpec{}
 		for _, pkg := range RGetSpecFile().Packages {
 			pkgs[api.PkgName(pkg.Name)] = api.PkgSpec(pkg.Version)

--- a/internal/backends/ruby/ruby.go
+++ b/internal/backends/ruby/ruby.go
@@ -232,7 +232,7 @@ var RubyBackend = api.LanguageBackend{
 		}
 		util.RunCmd([]string{"bundle", "install"})
 	},
-	ListSpecfile: func() map[api.PkgName]api.PkgSpec {
+	ListSpecfile: func(mergeAllGroups bool) map[api.PkgName]api.PkgSpec {
 		outputB := util.GetCmdOutput([]string{
 			"ruby", "-e", util.GetResource("/ruby/list-specfile.rb"),
 		})

--- a/internal/backends/rust/rust.go
+++ b/internal/backends/rust/rust.go
@@ -150,7 +150,7 @@ func info(name api.PkgName) api.PkgInfo {
 	return crateInfo.toPkgInfo()
 }
 
-func listSpecfile() map[api.PkgName]api.PkgSpec {
+func listSpecfile(mergeAllGroups bool) map[api.PkgName]api.PkgSpec {
 	contents, err := os.ReadFile("Cargo.toml")
 	if err != nil {
 		util.DieIO("Cargo.toml: %s", err)

--- a/internal/cli/cmds.go
+++ b/internal/cli/cmds.go
@@ -312,7 +312,7 @@ func runAdd(
 
 	if util.Exists(b.Specfile) {
 		s := silenceSubroutines()
-		for name := range b.ListSpecfile() {
+		for name := range b.ListSpecfile(true) {
 			delete(normPkgs, b.NormalizePackageName(name))
 		}
 		s.restore()
@@ -359,7 +359,7 @@ func runRemove(language string, args []string, upgrade bool,
 	}
 
 	s := silenceSubroutines()
-	specfilePkgs := b.ListSpecfile()
+	specfilePkgs := b.ListSpecfile(false)
 	s.restore()
 
 	// Map whose keys are normalized package names.
@@ -464,7 +464,7 @@ func runList(language string, all bool, outputFormat outputFormat) {
 		var results map[api.PkgName]api.PkgSpec = nil
 		fileExists := util.Exists(b.Specfile)
 		if fileExists {
-			results = b.ListSpecfile()
+			results = b.ListSpecfile(false)
 		}
 		switch outputFormat {
 		case outputFormatTable:
@@ -564,7 +564,7 @@ func runGuess(
 
 	if !all {
 		if util.Exists(b.Specfile) {
-			for name := range b.ListSpecfile() {
+			for name := range b.ListSpecfile(true) {
 				name := b.NormalizePackageName(name)
 				for key, pkgs := range normPkgs {
 					for _, pkg := range pkgs {

--- a/internal/cli/cmds.go
+++ b/internal/cli/cmds.go
@@ -464,7 +464,7 @@ func runList(language string, all bool, outputFormat outputFormat) {
 		var results map[api.PkgName]api.PkgSpec = nil
 		fileExists := util.Exists(b.Specfile)
 		if fileExists {
-			results = b.ListSpecfile(false)
+			results = b.ListSpecfile(true)
 		}
 		switch outputFormat {
 		case outputFormatTable:

--- a/internal/cli/cmds.go
+++ b/internal/cli/cmds.go
@@ -359,7 +359,7 @@ func runRemove(language string, args []string, upgrade bool,
 	}
 
 	s := silenceSubroutines()
-	specfilePkgs := b.ListSpecfile(false)
+	specfilePkgs := b.ListSpecfile(true)
 	s.restore()
 
 	// Map whose keys are normalized package names.


### PR DESCRIPTION
Why
===

As we prepare to merge #240, it will be good to filter out known-but-optional dependencies to avoid noise.

What changed
============

- Described poetry dependency groups
- Added a `mergeAllGroups bool` to `ListSpecfile` to include all dependency specs that we could find

Test plan
=========

```bash
$ poetry init -n
$ echo 'import flask' > main.py
$ upm guess  # Outputs "flask"
$ poetry add -G foo flask
$ upm guess  # No longer outputs anything
```