### PR TITLE
Skip upm lock when specfile lists no pkgs (DX-575)

### DIFF
--- a/internal/cli/cmds.go
+++ b/internal/cli/cmds.go
@@ -218,8 +218,9 @@ func maybeLock(ctx context.Context, b api.LanguageBackend, forceLock bool) bool 
 
 	shouldLock := forceLock || !util.Exists(b.Lockfile) || store.HasSpecfileChanged(b)
 	if !shouldLock {
-		if packageDir := b.GetPackageDir(); packageDir != "" {
-			shouldLock = !util.Exists(packageDir)
+		if packageDir := b.GetPackageDir(); packageDir != "" && !util.Exists(packageDir) {
+			// Only run lock if a specfile exists and it lists at least one package.
+			shouldLock = util.Exists(b.Specfile) && len(b.ListSpecfile(true)) > 0
 		}
 	}
 


### PR DESCRIPTION
Why
===

https://linear.app/replit/issue/DX-575/upm-lock-can-run-multiple-times-if-packagedir-doesnt-get-created

What changed
============

In the previous scenarios with no package folder (like .pythonlibs) where upm lock was always running, now upm will only run lock if the specfile exists and contains at least one package.

Test plan
=========

Tested out python template locally with no pythonlibs folder. I don't see packager messages when I don't change dependencies.
