### PR TITLE
DX-592: Add portaudio dep for pyaudio

### DIFF
--- a/internal/nix/python_map.json
+++ b/internal/nix/python_map.json
@@ -415,6 +415,7 @@
   "pyarrow":{"deps":["pkgs.arrow-cpp","pkgs.pkg-config"]},
   "pyatspi":{"deps":["pkgs.at-spi2-core","pkgs.pkg-config"]},
   "pyautogui":{"deps":["pkgs.scrot","pkgs.xvfb-run"]},
+  "pyaudio":{"deps":["pkgs.pulseaudio"]},
   "pybigwig":{"deps":["pkgs.zlib"]},
   "pybind11":{"deps":["pkgs.catch","pkgs.eigen","pkgs.libxcrypt"]},
   "pybluez":{"deps":["pkgs.bluez"]},

--- a/internal/nix/python_map.json
+++ b/internal/nix/python_map.json
@@ -415,7 +415,7 @@
   "pyarrow":{"deps":["pkgs.arrow-cpp","pkgs.pkg-config"]},
   "pyatspi":{"deps":["pkgs.at-spi2-core","pkgs.pkg-config"]},
   "pyautogui":{"deps":["pkgs.scrot","pkgs.xvfb-run"]},
-  "pyaudio":{"deps":["pkgs.pulseaudio"]},
+  "pyaudio":{"deps":["pkgs.portaudio"]},
   "pybigwig":{"deps":["pkgs.zlib"]},
   "pybind11":{"deps":["pkgs.catch","pkgs.eigen","pkgs.libxcrypt"]},
   "pybluez":{"deps":["pkgs.bluez"]},


### PR DESCRIPTION
Why
===

Unable to install pyaudio due to not having portaudio deps available.

What changed
============

Add `pkgs.portaudio` to satisfy that dep

Test plan
=========

`import pyaudio` in `main.py` in a fresh Python repl should have `pkgs.portaudio` in the `replit.nix` after automatic package installation