### PR TITLE
DX-593: Adding edgartools

### DIFF
--- a/internal/backends/python/pypi_map.override.go
+++ b/internal/backends/python/pypi_map.override.go
@@ -10,6 +10,7 @@ var moduleToPypiPackageOverride = map[string][]string{
 	"nvd3":                 {"python-nvd3"},                                          // not popular enough 6th in popularity
 	"requirements":         {"requirements-parser"},                                  // popular rlbot depends on it, but doesn't supply requires_dist
 	"base62":               {"pybase62"},                                             // it was overridden by base-62 which wins due to name match but is less popular by far
+	"edgar":                {"edgartools", "edgar"},                                  // Two different tools to access the Edgar service provided by the SEC, edgartools is more active
 	"faiss":                {"faiss-cpu"},                                            // faiss is offered as precompiled wheels, faiss-cpu and faiss-gpu.
 	"graphics":             {"graphics.py"},                                          // this package is popular, but the module doesn't match the package name https://anh.cs.luc.edu/python/hands-on/3.1/handsonHtml/graphics.html#a-graphics-introduction
 	"replit.ai":            {"replit-ai"},                                            // Replit's AI package


### PR DESCRIPTION
Why
===

Both edgartools and edgar provide the package `edgar`. edgartools seems to have more activity recently, but it's a toss-up of which should be preferred.

What changed
============

Add `edgar` package mapping

Test plan
=========

`import edgar` should install edgartools