### PR TITLE
[nix] update build-go-cache usage

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,21 +2,63 @@
   "nodes": {
     "build-go-cache": {
       "inputs": {
+        "gomod2nix": "gomod2nix",
         "nixpkgs": [
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1698326400,
-        "narHash": "sha256-29dSO5Icpk+zM0xYYJBk5wOFTA2zARNbq9N6+ZEX0d8=",
+        "lastModified": 1699381303,
+        "narHash": "sha256-qi1FdxpIfHrx6T3W2ck7WOoP2B486H3WSRPFMPJtofs=",
         "owner": "numtide",
         "repo": "build-go-cache",
-        "rev": "22bdf84c03c0073e52c6889842a1ae098cc8c8dd",
+        "rev": "1f0056d94c4097cf8cfc9ed9c1864e400f689c6b",
         "type": "github"
       },
       "original": {
         "owner": "numtide",
         "repo": "build-go-cache",
+        "rev": "1f0056d94c4097cf8cfc9ed9c1864e400f689c6b",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1694529238,
+        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "gomod2nix": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": [
+          "build-go-cache",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1716202913,
+        "narHash": "sha256-zjPNXI4DWBOrPsrK8u/XTsm5Q36quONQvz0jhAKHEeg=",
+        "owner": "nix-community",
+        "repo": "gomod2nix",
+        "rev": "4702caff8e201f4c98fe3583637a930d253447c8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "gomod2nix",
         "type": "github"
       }
     },
@@ -61,6 +103,21 @@
         "build-go-cache": "build-go-cache",
         "nix-editor": "nix-editor",
         "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   inputs.nix-editor.url = "github:replit/nix-editor";
   inputs.nix-editor.inputs.nixpkgs.follows = "nixpkgs";
 
-  inputs.build-go-cache.url = "github:numtide/build-go-cache";
+  inputs.build-go-cache.url = "github:numtide/build-go-cache/1f0056d94c4097cf8cfc9ed9c1864e400f689c6b";
   inputs.build-go-cache.inputs.nixpkgs.follows = "nixpkgs";
 
   outputs = {

--- a/nix/upm/default.nix
+++ b/nix/upm/default.nix
@@ -19,6 +19,7 @@ let
       install -D ${../../go.sum} $out/go.sum
     '';
     inherit vendorHash;
+    proxyVendor = true;
   };
 in
 buildGoModule rec {


### PR DESCRIPTION
Why
===
* build-go-cache stopped working if you pass vendorHash without also passing proxyVendor:
```
… while calling the 'derivationStrict' builtin
     at <nix/derivation-internal.nix>:9:12:
        8|
        9|   strict = derivationStrict drvAttrs;
         |            ^
       10|
… while evaluating derivation 'upm-0.0.0-dirty'
     whose name attribute is located at /nix/store/xxg0317r42hi568l55dvilyn92kgdrd0-source/pkgs/stdenv/generic/make-derivation.nix:300:7
… while evaluating attribute 'buildInputs' of derivation 'upm-0.0.0-dirty'
     at /nix/store/xxg0317r42hi568l55dvilyn92kgdrd0-source/pkgs/stdenv/generic/make-derivation.nix:347:7:
      346|       depsHostHost                = lib.elemAt (lib.elemAt dependencies 1) 0;
      347|       buildInputs                 = lib.elemAt (lib.elemAt dependencies 1) 1;
         |       ^
      348|       depsTargetTarget            = lib.elemAt (lib.elemAt dependencies 2) 0;
(stack trace truncated; use '--show-trace' to show the full, detailed trace)
error: cannot coerce null to a string: null
```

What changed
===
* Pin build-go-cache to the version we are using in other projects, and the version that broke things
* Pass proxyVendor = true

Test plan
===
* `nix build` worked