### PR TITLE
Added entry for opencv-python dep on libgl

### DIFF
--- a/internal/nix/python_map.json
+++ b/internal/nix/python_map.json
@@ -351,6 +351,7 @@
   "openai-triton":{"deps":["pkgs.gtest","pkgs.ncurses","pkgs.zlib"]},
   "openai-whisper":{"deps":["pkgs.ffmpeg-full"]},
   "openbabel-bindings":{"deps":["pkgs.openbabel"]},
+  "opencv-python":{"deps":["pkgs.libGL","pkgs.libGLU"]},
   "opensfm":{"deps":["pkgs.ceres-solver","pkgs.eigen","pkgs.glog","pkgs.gtest","pkgs.metis","pkgs.pkg-config","pkgs.suitesparse"]},
   "opentimestamps":{"deps":["pkgs.gitFull"]},
   "opuslib":{"deps":["pkgs.libopus"]},


### PR DESCRIPTION
Why
===

opencv-python doesn't work on replit due to missing dep on libGL. https://replit.slack.com/archives/C03KS2B221W/p1716992546783999

There's a secondary issue: even with this fix, it still won't work if opencv needs to render UI. But that will be dealt with separately.

What changed
============

Added entry to in sysdep assistence for opencv-python->libGL.

Test plan
=========

1. create python repl
2. write `import cv2` in main.py
3. hit run. It should work
