### PR TITLE
DX-662: Avoid poetry list panic

### DIFF
--- a/internal/backends/python/python.go
+++ b/internal/backends/python/python.go
@@ -632,6 +632,9 @@ func listPoetrySpecfile(mergeAllGroups bool) (map[api.PkgName]api.PkgSpec, error
 		return nil, err
 	}
 	pkgs := map[api.PkgName]api.PkgSpec{}
+	if cfg.Tool.Poetry == nil {
+		return pkgs, nil
+	}
 	for nameStr, spec := range cfg.Tool.Poetry.Dependencies {
 		if nameStr == "python" {
 			continue

--- a/internal/cli/cmds.go
+++ b/internal/cli/cmds.go
@@ -313,8 +313,10 @@ func runAdd(
 
 	if util.Exists(b.Specfile) {
 		s := silenceSubroutines()
-		for name := range b.ListSpecfile(true) {
-			delete(normPkgs, b.NormalizePackageName(name))
+		for name, spec := range b.ListSpecfile(true) {
+			if spec == normPkgs[b.NormalizePackageName(name)].Spec {
+				delete(normPkgs, b.NormalizePackageName(name))
+			}
 		}
 		s.restore()
 	}


### PR DESCRIPTION
Why
===

Since pyproject.toml is not exclusive to Poetry, we shouldn't presume that the poetry section is present

What changed
============

If we detect that `[tool.poetry]` is null, bail before we try to dereference it.

Test plan
=========

In a blank repl,

```shell
$ touch pyproject.toml
$ upm -l python list
```

should not panic