### PR TITLE
Direct hubspot hopefuls to the correct library

### DIFF
--- a/internal/backends/python/pypi_map.override.go
+++ b/internal/backends/python/pypi_map.override.go
@@ -15,6 +15,7 @@ var moduleToPypiPackageOverride = map[string][]string{
 	"graphics":             {"graphics.py"},                                          // this package is popular, but the module doesn't match the package name https://anh.cs.luc.edu/python/hands-on/3.1/handsonHtml/graphics.html#a-graphics-introduction
 	"replit.ai":            {"replit-ai"},                                            // Replit's AI package
 	"glm":                  {"PyGLM", "glm"},                                         // Both of these packages are valid, but PyGLM is a library, glm is an executable.
+	"hubspot":              {"hubspot-api-client"},                                   // "hubspot" is a namesquatted library that has not been touched since 2014
 	"jwt":                  {"PyJWT", "jwt"},                                         // Both of these packages are valid, but PyJWT is more popular
 	"ldclient":             {"ldclient-py", "ldclient"},                              // LaunchDarkly client
 	"tensorflow":           append([]string{"tensorflow"}, tf_variants[:]...),        // Avoid suggesting conflicting tensorflow builds


### PR DESCRIPTION
Why
===

`hubspot` is a namesquatted library that hasn't been updated since 2014

What changed
============

Directing `upm guess` to use the official client instead of guessing this project

Test plan
=========

`import hubspot` should guess `hubspot-api-client`