### PR TITLE
Check error before using response

### DIFF
--- a/internal/backends/python/search_pypi.go
+++ b/internal/backends/python/search_pypi.go
@@ -20,11 +20,11 @@ func SearchPypi(query string) ([]api.PkgInfo, error) {
 		return nil, err
 	}
 	resp, err := api.HttpClient.Do(req)
-	if resp.StatusCode != 200 {
-		return nil, fmt.Errorf("Request to %s failed with %s", endpoint, resp.Status)
-	}
 	if err != nil {
 		return nil, err
+	}
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("Request to %s failed with %s", endpoint, resp.Status)
 	}
 	tree, err := html.Parse(resp.Body)
 	if err != nil {


### PR DESCRIPTION
Why
===

We found a nil deref error in a template test that suggests this as the culprit.

https://replit.slack.com/archives/C06KAKG35QS/p1719352272057069?thread_ts=1719341894.359499&cid=C06KAKG35QS

What changed
============

Reversed the order of operations.