### PR TITLE
chore(flake): update build-go-cache for less rebuild

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -8,17 +8,17 @@
         ]
       },
       "locked": {
-        "lastModified": 1699381303,
-        "narHash": "sha256-qi1FdxpIfHrx6T3W2ck7WOoP2B486H3WSRPFMPJtofs=",
+        "lastModified": 1721386404,
+        "narHash": "sha256-c5t/YVZEn+zsQKqU9cws4boHVNyt7LQNeaf+xdPeWGI=",
         "owner": "numtide",
         "repo": "build-go-cache",
-        "rev": "1f0056d94c4097cf8cfc9ed9c1864e400f689c6b",
+        "rev": "c5fa74cf7666a3fd7908d7ea91f8a6713ba5e838",
         "type": "github"
       },
       "original": {
         "owner": "numtide",
         "repo": "build-go-cache",
-        "rev": "1f0056d94c4097cf8cfc9ed9c1864e400f689c6b",
+        "rev": "c5fa74cf7666a3fd7908d7ea91f8a6713ba5e838",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   inputs.nix-editor.url = "github:replit/nix-editor";
   inputs.nix-editor.inputs.nixpkgs.follows = "nixpkgs";
 
-  inputs.build-go-cache.url = "github:numtide/build-go-cache/1f0056d94c4097cf8cfc9ed9c1864e400f689c6b";
+  inputs.build-go-cache.url = "github:numtide/build-go-cache/c5fa74cf7666a3fd7908d7ea91f8a6713ba5e838";
   inputs.build-go-cache.inputs.nixpkgs.follows = "nixpkgs";
 
   outputs = {


### PR DESCRIPTION
Why
===

This is a small developer UX issue. In some cases, Nix would rebuild instead of fetching the result from the binary cache.

What changed
============

https://github.com/numtide/build-go-cache/pull/9 

Thanks to katexochen for fixing this issue.

Test plan
=========

_Describe what you did to test this change to a level of detail that allows your reviewer to test it_
