### PR TITLE
[node] Adding nodejs package alias mapping

### DIFF
--- a/internal/backends/nodejs/grab.go
+++ b/internal/backends/nodejs/grab.go
@@ -195,6 +195,10 @@ func filterImports(ctx context.Context, foundPaths map[string]bool) map[string][
 			}
 		}
 
+		if pkg, ok := moduleToNpmjsPackageAliases[mod]; ok {
+			mod = pkg
+		}
+
 		pkgs[mod] = []api.PkgName{api.PkgName(mod)}
 	}
 

--- a/internal/backends/nodejs/nodejs.go
+++ b/internal/backends/nodejs/nodejs.go
@@ -416,7 +416,13 @@ var NodejsYarnBackend = api.LanguageBackend{
 		}
 		cmd := []string{"yarn", "add"}
 		for name, spec := range pkgs {
-			arg := string(name)
+			name := string(name)
+			if found, ok := moduleToYarnpkgPackageAliases[name]; ok {
+				delete(pkgs, api.PkgName(name))
+				name = found
+				pkgs[api.PkgName(name)] = api.PkgSpec(spec)
+			}
+			arg := name
 			if spec != "" {
 				arg += "@" + string(spec)
 			}
@@ -493,7 +499,13 @@ var NodejsPNPMBackend = api.LanguageBackend{
 		}
 		cmd := []string{"pnpm", "add"}
 		for name, spec := range pkgs {
-			arg := string(name)
+			name := string(name)
+			if found, ok := moduleToNpmjsPackageAliases[name]; ok {
+				delete(pkgs, api.PkgName(name))
+				name = found
+				pkgs[api.PkgName(name)] = api.PkgSpec(spec)
+			}
+			arg := name
 			if spec != "" {
 				arg += "@" + string(spec)
 			}
@@ -587,7 +599,13 @@ var NodejsNPMBackend = api.LanguageBackend{
 		}
 		cmd := []string{"npm", "install"}
 		for name, spec := range pkgs {
-			arg := string(name)
+			name := string(name)
+			if found, ok := moduleToNpmjsPackageAliases[name]; ok {
+				delete(pkgs, api.PkgName(name))
+				name = found
+				pkgs[api.PkgName(name)] = api.PkgSpec(spec)
+			}
+			arg := name
 			if spec != "" {
 				arg += "@" + string(spec)
 			}
@@ -671,7 +689,13 @@ var BunBackend = api.LanguageBackend{
 		}
 		cmd := []string{"bun", "add"}
 		for name, spec := range pkgs {
-			arg := string(name)
+			name := string(name)
+			if found, ok := moduleToNpmjsPackageAliases[name]; ok {
+				delete(pkgs, api.PkgName(name))
+				name = found
+				pkgs[api.PkgName(name)] = api.PkgSpec(spec)
+			}
+			arg := name
 			if spec != "" {
 				arg += "@" + string(spec)
 			}

--- a/internal/backends/nodejs/nodejs.override.go
+++ b/internal/backends/nodejs/nodejs.override.go
@@ -1,0 +1,14 @@
+package nodejs
+
+/* Proxy packages
+ *
+ * These are packages that provide helpful aliases, but otherwise provide no functionality.
+ * We should prefer the real version.
+ */
+var moduleToNpmjsPackageAliases = map[string]string{
+	"tsc": "typescript",
+}
+
+var moduleToYarnpkgPackageAliases = map[string]string{
+	"tsc": "typescript",
+}


### PR DESCRIPTION
Why
===

Similar to Python, there are some packages that need overriding. To start, `tsc`, which emits the following if you install it by accident:

![image](https://github.com/user-attachments/assets/a4942d77-b5e1-4bed-9c6f-a1522ff65413)

What changed
============

- Introduced new mappings for npmjs.com as well as yarnpkg.com
- Altered the different Javascript packagers to consider these overrides when doing `add` or `grab`

Test plan
=========

`upm add tsc` should install `typescript` instead:

```
$ upm add tsc
--> bun add typescript
bun add v1.0.18 (36c316a2)

 installed typescript@5.5.4 with binaries:
  - tsc
  - tsserver


 1 package installed [555.00ms]
```