### PR TITLE
bug/Force install if packagedir missing

### DIFF
--- a/internal/cli/cmds.go
+++ b/internal/cli/cmds.go
@@ -241,7 +241,11 @@ func maybeInstall(ctx context.Context, b api.LanguageBackend, forceInstall bool)
 		if !util.Exists(b.Lockfile) {
 			return
 		}
-		if forceInstall || store.HasLockfileChanged(b) {
+		var needsPackageDir bool
+		if packageDir := b.GetPackageDir(); packageDir != "" {
+			needsPackageDir = !util.Exists(packageDir)
+		}
+		if forceInstall || store.HasSpecfileChanged(b) || needsPackageDir {
 			b.Install(ctx)
 		}
 	} else {


### PR DESCRIPTION
Why
===

If the package directory doesn't exist, we must install regardless.

What changed
============

For `poetry`, `lock` was not detecting that the `.pythonlibs` directory did not exist. We need to force lock in that case.

Test plan
=========

Running
```
rm -rf .pythonlibs .upm poetry.lock
```
and then hitting `Run` should force lock and start the command successfully.