### PR TITLE
bug/Only force needsPackageDir if we have packages to install

### DIFF
--- a/internal/cli/cmds.go
+++ b/internal/cli/cmds.go
@@ -242,7 +242,7 @@ func maybeInstall(ctx context.Context, b api.LanguageBackend, forceInstall bool)
 			return
 		}
 		var needsPackageDir bool
-		if packageDir := b.GetPackageDir(); packageDir != "" {
+		if packageDir := b.GetPackageDir(); len(b.ListSpecfile(false)) > 0 && packageDir != "" {
 			needsPackageDir = !util.Exists(packageDir)
 		}
 		if forceInstall || store.HasSpecfileChanged(b) || needsPackageDir {


### PR DESCRIPTION
Why
===

We've been having a regression on metrics for zero-package installs, turns out it's because we were invoking poetry when we had no work to do.

What changed
============

Gate `needsPackageDir` on whether we have packages to install. No sense in doing work when we don't need to.

Test plan
=========

We should see the time-to-install go down after this is deployed