### PR TITLE
Update nixpkgs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -84,11 +84,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1694062546,
-        "narHash": "sha256-PiGI4f2BGnZcedP6slLjCLGLRLXPa9+ogGGgVPfGxys=",
+        "lastModified": 1724300212,
+        "narHash": "sha256-x3jl6OWTs+L9C7EtscuWZmGZWI0iSBDafvg3X7JMa1A=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b200e0df08f80c32974a6108ce431d8a8a5e6547",
+        "rev": "4de4818c1ffa76d57787af936e8a23648bda6be4",
         "type": "github"
       },
       "original": {

--- a/nix/devshell/default.nix
+++ b/nix/devshell/default.nix
@@ -5,6 +5,7 @@
   nodejs,
   nodePackages,
   nix-editor,
+  pnpm_8,
   poetry,
   python310Full,
   python310Packages,
@@ -18,7 +19,7 @@ mkShell {
     golangci-lint
     nix-editor
     nodejs
-    nodePackages.pnpm
+    pnpm_8
     nodePackages.yarn
     python310Packages.pip
     poetry

--- a/nix/upm/default.nix
+++ b/nix/upm/default.nix
@@ -3,11 +3,10 @@
   rev,
   makeWrapper,
   buildGoCache,
-  lib,
   runCommand,
 }:
 let
-  vendorHash = "sha256-LegOSckmhod3Yri1YrV7BHFkzZnMSaQjumDRffOs/Aw=";
+  vendorHash = "sha256-vHWl1t/tZ1siHJpxazIzkD3FSYokPm7KZVnM+X02O9Q=";
 
   goCache = buildGoCache {
     # keep this up-to-date in CI with:


### PR DESCRIPTION
Why
===

Updated to a more recent version of nixpkgs, which results in go cache vendor hash needing to be updated

What changed
============

- Updated nixpkgs
- Updated the vendorHash

Test plan
=========

nix build .#upm

