### PR TITLE
chore/Reflow test populator

### DIFF
--- a/internal/backends/python/modules.go
+++ b/internal/backends/python/modules.go
@@ -31,7 +31,7 @@ func (state *moduleState) isModuleLocalToRoot(pkg string, root string) bool {
 	last := components[len(components)-1]
 	components = components[:len(components)-1]
 
-	return state.isModuleComponent(path.Join(components...), last)
+	return state.isModuleComponent(path.Join(append([]string{root}, components...)...), last)
 }
 
 // Test to see if a dotted package, `pkg`, is a python module, relative to any project root

--- a/internal/backends/python/python.go
+++ b/internal/backends/python/python.go
@@ -292,6 +292,21 @@ func commonInstallNixDeps(ctx context.Context, pkgs []api.PkgName, specfilePkgs 
 	nix.RunNixEditorOps(ops)
 }
 
+func commonGuessPackageDir() string {
+	// Check if we're already inside an activated
+	// virtualenv. If so, just use it.
+	if venv := os.Getenv("VIRTUAL_ENV"); venv != "" {
+		return venv
+	}
+
+	// Take PYTHONUSERBASE into consideration, if set
+	if userbase := os.Getenv("PYTHONUSERBASE"); userbase != "" {
+		return userbase
+	}
+
+	return ""
+}
+
 // makePythonPoetryBackend returns a backend for invoking poetry
 func makePythonPoetryBackend() api.LanguageBackend {
 	return api.LanguageBackend{
@@ -307,15 +322,9 @@ func makePythonPoetryBackend() api.LanguageBackend {
 		NormalizePackageArgs: normalizePackageArgs,
 		NormalizePackageName: normalizePackageName,
 		GetPackageDir: func() string {
-			// Check if we're already inside an activated
-			// virtualenv. If so, just use it.
-			if venv := os.Getenv("VIRTUAL_ENV"); venv != "" {
-				return venv
-			}
-
-			// Take PYTHONUSERBASE into consideration, if set
-			if userbase := os.Getenv("PYTHONUSERBASE"); userbase != "" {
-				return userbase
+			pkgdir := commonGuessPackageDir()
+			if pkgdir != "" {
+				return pkgdir
 			}
 
 			// Terminate early if we're running inside a repl.
@@ -431,15 +440,9 @@ func makePythonPipBackend() api.LanguageBackend {
 		NormalizePackageArgs: normalizePackageArgs,
 		NormalizePackageName: normalizePackageName,
 		GetPackageDir: func() string {
-			// Check if we're already inside an activated
-			// virtualenv. If so, just use it.
-			if venv := os.Getenv("VIRTUAL_ENV"); venv != "" {
-				return venv
-			}
-
-			// Take PYTHONUSERBASE into consideration, if set
-			if userbase := os.Getenv("PYTHONUSERBASE"); userbase != "" {
-				return userbase
+			pkgdir := commonGuessPackageDir()
+			if pkgdir != "" {
+				return pkgdir
 			}
 
 			if outputB, err := util.GetCmdOutputFallible([]string{

--- a/internal/backends/python/python.go
+++ b/internal/backends/python/python.go
@@ -275,9 +275,8 @@ func searchPypi(query string) []api.PkgInfo {
 	return filtered
 }
 
-// makePythonPoetryBackend returns a backend for invoking poetry, given an arg0 for invoking Python
-// (either a full path or just a name like "python3") to use when invoking Python.
-func makePythonPoetryBackend(python string) api.LanguageBackend {
+// makePythonPoetryBackend returns a backend for invoking poetry
+func makePythonPoetryBackend() api.LanguageBackend {
 	return api.LanguageBackend{
 		Name:                 "python3-poetry",
 		Alias:                "python-python3-poetry",
@@ -414,9 +413,8 @@ var pythonGuessRegexps = util.Regexps([]string{
 	`import ((?:.|\\\n)*)`,
 })
 
-// makePythonPipBackend returns a backend for invoking poetry, given an arg0 for invoking Python
-// (either a full path or just a name like "python3") to use when invoking Python.
-func makePythonPipBackend(python string) api.LanguageBackend {
+// makePythonPipBackend returns a backend for invoking pip.
+func makePythonPipBackend() api.LanguageBackend {
 	var pipFlags []PipFlag
 
 	b := api.LanguageBackend{
@@ -672,17 +670,6 @@ func listPoetrySpecfile(mergeAllGroups bool) (map[api.PkgName]api.PkgSpec, error
 	return pkgs, nil
 }
 
-// getPython3 returns either "python3" or the value of the UPM_PYTHON3
-// environment variable.
-func getPython3() string {
-	python3 := os.Getenv("UPM_PYTHON3")
-	if python3 != "" {
-		return python3
-	} else {
-		return "python3"
-	}
-}
-
 // PythonPoetryBackend is a UPM backend for Python 3 that uses Poetry.
-var PythonPoetryBackend = makePythonPoetryBackend(getPython3())
-var PythonPipBackend = makePythonPipBackend(getPython3())
+var PythonPoetryBackend = makePythonPoetryBackend()
+var PythonPipBackend = makePythonPipBackend()

--- a/internal/backends/python/requirements.go
+++ b/internal/backends/python/requirements.go
@@ -20,6 +20,7 @@ import (
 var pep345Name = `(?:[A-Z0-9]|[A-Z0-9][A-Z0-9._-]*[A-Z0-9])`
 var pep440VersionComponent = `(?:(?:~=|!=|===|==|>=|<=|>|<)\s*[^, ]+)`
 var pep440VersionSpec = pep440VersionComponent + `(?:\s*,\s*` + pep440VersionComponent + `)*`
+var matchSpecOnly = regexp.MustCompile(`^` + pep440VersionSpec + `$`)
 var extrasSpec = `\[(` + pep345Name + `(?:\s*,\s*` + pep345Name + `)*)\]`
 var matchPackageAndSpec = regexp.MustCompile(`(?i)^\s*(` + pep345Name + `)\s*` + `((?:` + extrasSpec + `)?\s*(?:` + pep440VersionSpec + `)?)?\s*$`)
 var matchEggComponent = regexp.MustCompile(`(?i)\begg=(` + pep345Name + `)(?:$|[^A-Z0-9])`)

--- a/test-suite/Add_test.go
+++ b/test-suite/Add_test.go
@@ -39,23 +39,20 @@ func TestAdd(t *testing.T) {
 
 func doAdd(bt testUtils.BackendT, pkgs ...string) {
 	for _, tmpl := range standardTemplates {
-		template := bt.Backend.Name + "/" + tmpl + "/"
 
 		if tmpl != "no-deps" {
 			bt.Subtest(tmpl, func(bt testUtils.BackendT) {
 				if bt.Backend.QuirksIsReproducible() {
 					bt.Subtest("locked", func(bt testUtils.BackendT) {
 						bt.Subtest("each", func(bt testUtils.BackendT) {
-							bt.AddTestFile(template+bt.Backend.Specfile, bt.Backend.Specfile)
-							bt.AddTestFile(template+bt.Backend.Lockfile, bt.Backend.Lockfile)
+							bt.AddTestDir(tmpl)
 							for _, pkg := range pkgs {
 								bt.UpmAdd(pkg)
 							}
 						})
 
 						bt.Subtest("all", func(bt testUtils.BackendT) {
-							bt.AddTestFile(template+bt.Backend.Specfile, bt.Backend.Specfile)
-							bt.AddTestFile(template+bt.Backend.Lockfile, bt.Backend.Lockfile)
+							bt.AddTestDir(tmpl)
 							bt.UpmAdd(pkgs...)
 						})
 					})
@@ -63,14 +60,14 @@ func doAdd(bt testUtils.BackendT, pkgs ...string) {
 
 				bt.Subtest("unlocked", func(bt testUtils.BackendT) {
 					bt.Subtest("each", func(bt testUtils.BackendT) {
-						bt.AddTestFile(template+bt.Backend.Specfile, bt.Backend.Specfile)
+						bt.AddTestDir(tmpl)
 						for _, pkg := range pkgs {
 							bt.UpmAdd(pkg)
 						}
 					})
 
 					bt.Subtest("all", func(bt testUtils.BackendT) {
-						bt.AddTestFile(template+bt.Backend.Specfile, bt.Backend.Specfile)
+						bt.AddTestDir(tmpl)
 						bt.UpmAdd(pkgs...)
 					})
 				})

--- a/test-suite/Guess_test.go
+++ b/test-suite/Guess_test.go
@@ -73,7 +73,7 @@ func TestGuess(t *testing.T) {
 
 							bt.Subtest(test, func(bt testUtils.BackendT) {
 								bt.AddTestFile(testSrcFile, test+"."+ext)
-								bt.AddTestFile(bt.Backend.Name+"/no-deps/"+bt.Backend.Specfile, bt.Backend.Specfile)
+								bt.AddTestDir("no-deps")
 
 								expectFile, err := templates.FS.Open(testSrcFile + ".expect")
 								if err != nil {

--- a/test-suite/Install_test.go
+++ b/test-suite/Install_test.go
@@ -38,13 +38,8 @@ func doInstall(bt testUtils.BackendT) {
 			continue
 		}
 
-		template := bt.Backend.Name + "/" + tmpl + "/"
 		bt.Subtest(tmpl, func(bt testUtils.BackendT) {
-			bt.AddTestFile(template+bt.Backend.Specfile, bt.Backend.Specfile)
-			if bt.Backend.QuirksIsReproducible() {
-				bt.AddTestFile(template+bt.Backend.Lockfile, bt.Backend.Lockfile)
-			}
-
+			bt.AddTestDir(tmpl)
 			bt.UpmInstall()
 
 			packageDirPath := bt.UpmPackageDir()

--- a/test-suite/List_test.go
+++ b/test-suite/List_test.go
@@ -69,12 +69,10 @@ func TestList(t *testing.T) {
 
 func doList(bt testUtils.BackendT, templatesToPackages map[string][]string) {
 	for tmpl, expectPkgs := range templatesToPackages {
-		template := bt.Backend.Name + "/" + tmpl + "/"
-
 		bt.Subtest(tmpl, func(bt testUtils.BackendT) {
-			bt.AddTestFile(template+bt.Backend.Specfile, bt.Backend.Specfile)
-			if tmpl != "no-deps" && bt.Backend.QuirksIsReproducible() {
-				bt.AddTestFile(template+bt.Backend.Lockfile, bt.Backend.Lockfile)
+			bt.AddTestDir(tmpl)
+			if tmpl == "no-deps" && bt.Backend.QuirksIsReproducible() {
+				bt.RemoveTestFile(bt.Backend.Lockfile)
 			}
 
 			specs := bt.UpmListSpecFile()

--- a/test-suite/Remove_test.go
+++ b/test-suite/Remove_test.go
@@ -51,23 +51,19 @@ func TestRemove(t *testing.T) {
 
 func doRemove(bt testUtils.BackendT, templatesToPkgsToRemove map[string][]string) {
 	for tmpl, pkgsToRemove := range templatesToPkgsToRemove {
-		template := bt.Backend.Name + "/" + tmpl + "/"
-
 		if tmpl != "no-deps" {
 			bt.Subtest(tmpl, func(bt testUtils.BackendT) {
 				if bt.Backend.QuirksIsReproducible() {
 					bt.Subtest("locked", func(bt testUtils.BackendT) {
 						bt.Subtest("each", func(bt testUtils.BackendT) {
-							bt.AddTestFile(template+bt.Backend.Specfile, bt.Backend.Specfile)
-							bt.AddTestFile(template+bt.Backend.Lockfile, bt.Backend.Lockfile)
+							bt.AddTestDir(tmpl)
 							for _, pkg := range pkgsToRemove {
 								bt.UpmRemove(pkg)
 							}
 						})
 
 						bt.Subtest("all", func(bt testUtils.BackendT) {
-							bt.AddTestFile(template+bt.Backend.Specfile, bt.Backend.Specfile)
-							bt.AddTestFile(template+bt.Backend.Lockfile, bt.Backend.Lockfile)
+							bt.AddTestDir(tmpl)
 							bt.UpmRemove(pkgsToRemove...)
 						})
 					})
@@ -76,14 +72,16 @@ func doRemove(bt testUtils.BackendT, templatesToPkgsToRemove map[string][]string
 				if !bt.Backend.QuirkRemoveNeedsLockfile() {
 					bt.Subtest("unlocked", func(bt testUtils.BackendT) {
 						bt.Subtest("each", func(bt testUtils.BackendT) {
-							bt.AddTestFile(template+bt.Backend.Specfile, bt.Backend.Specfile)
+							bt.AddTestDir(tmpl)
+							bt.RemoveTestFile(bt.Backend.Lockfile)
 							for _, pkg := range pkgsToRemove {
 								bt.UpmRemove(pkg)
 							}
 						})
 
 						bt.Subtest("all", func(bt testUtils.BackendT) {
-							bt.AddTestFile(template+bt.Backend.Specfile, bt.Backend.Specfile)
+							bt.AddTestDir(tmpl)
+							bt.RemoveTestFile(bt.Backend.Lockfile)
 							bt.UpmRemove(pkgsToRemove...)
 						})
 					})

--- a/test-suite/WhichLanguage_test.go
+++ b/test-suite/WhichLanguage_test.go
@@ -30,25 +30,23 @@ func TestWhichLanguage(t *testing.T) {
 			continue
 		}
 
-		template := bt.Backend.Name + "/one-dep/"
-
 		bt.Subtest(bt.Backend.Name, func(bt testUtils.BackendT) {
 			if bt.Backend.QuirksIsReproducible() {
 				bt.Subtest("locked", func(bt testUtils.BackendT) {
-					bt.AddTestFile(template+bt.Backend.Specfile, bt.Backend.Specfile)
-					bt.AddTestFile(template+bt.Backend.Lockfile, bt.Backend.Lockfile)
+					bt.AddTestDir("one-dep")
 					bt.UpmWhichLanguage()
 				})
 			} else {
 				bt.Subtest("no lockfile", func(bt testUtils.BackendT) {
-					bt.AddTestFile(template+bt.Backend.Specfile, bt.Backend.Specfile)
+					bt.AddTestDir("one-dep")
 					bt.UpmWhichLanguage()
 				})
 			}
 
 			if defaults[bt.Backend.Name] {
 				bt.Subtest("default", func(bt testUtils.BackendT) {
-					bt.AddTestFile(template+bt.Backend.Specfile, bt.Backend.Specfile)
+					bt.AddTestDir("one-dep")
+					bt.RemoveTestFile(bt.Backend.Lockfile)
 					bt.UpmWhichLanguage()
 				})
 			}

--- a/test-suite/utils/backend_t.go
+++ b/test-suite/utils/backend_t.go
@@ -62,6 +62,55 @@ func (bt *BackendT) TestDir() string {
 	return bt.testDir
 }
 
+// AddTestDir relies on test-suite/templates/templates.go's embedded files,
+// iterating over every bt.Backend.Name+"/"+tmpl recursively and copying them
+// into the ephemeral test directory.
+//
+// Note, this relies on empty path segments, since the source and target path
+// formats are slightly different. The source path includes the
+// test classifier (no-deps, one-dep, etc), whereas the target expects every
+// copied file to be copied into TestDir directly.
+func (bt *BackendT) AddTestDir(tmpl string) {
+	var rec func(cur string)
+	rec = func(cur string) {
+		entries, _ := bt.templates.ReadDir(path.Join(bt.Backend.Name, tmpl, cur))
+		for _, entry := range entries {
+			// Combine the current path segment with the src or dst roots
+			srcpath := path.Join(bt.Backend.Name, tmpl, cur, entry.Name())
+			dstpath := path.Join(bt.TestDir(), cur, entry.Name())
+			if entry.IsDir() {
+				err := os.MkdirAll(dstpath, 0o755)
+				if err != nil {
+					bt.Fail("Unable to create %s", dstpath)
+				}
+				rec(path.Join(cur, entry.Name()))
+			} else {
+				f, err := bt.templates.Open(srcpath)
+				if err != nil {
+					bt.t.Fatalf("failed to get template %s: %v", srcpath, err)
+				}
+
+				dst, err := os.OpenFile(dstpath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o644)
+				if err != nil {
+					bt.t.Fatalf("failed to open or create test file %s: %v", dstpath, err)
+				}
+
+				_, err = io.Copy(dst, f)
+				if err != nil {
+					bt.t.Fatalf("failed to read template %s: %v", srcpath, err)
+				}
+			}
+		}
+	}
+
+	rec("")
+}
+
+func (bt *BackendT) RemoveTestFile(fpath string) {
+	fullPath := path.Join(bt.TestDir(), fpath)
+	os.Remove(fullPath)
+}
+
 func (bt *BackendT) AddTestFile(template, as string) {
 	templates := *bt.templates
 


### PR DESCRIPTION
Why
===

To support #244, do some housekeeping.

What changed
============

- Reorganize `python/python.go`. Reduce spaghetti by a bit.
- We shouldn't care about how to populate a project during tests. We know the files are embedded, we can recurse the directories and copy the files into a target. All this file path juggling is unnecessary.

Test plan
=========

CI should still pass