### PR TITLE
feat/uv project envvar support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,5 +128,5 @@ wrapped-test-%:
 	UPM_SUITE_PREFIX="$$suite_prefix" go test
 endif
 
-fmt:
+format:
 	go fmt github.com/replit/upm/...

--- a/internal/backends/python/python.go
+++ b/internal/backends/python/python.go
@@ -755,7 +755,12 @@ func makePythonUvBackend() api.LanguageBackend {
 				return pkgdir
 			}
 
-			return ""
+			retval := os.Getenv("UV_PROJECT_ENVIRONMENT")
+			if retval != "" {
+				return retval
+			}
+
+			return ".venv"
 		},
 		SortPackages: pkg.SortPrefixSuffix(normalizePackageName),
 


### PR DESCRIPTION
Why
===

- 0.4.4 was released, including support for customizing the `.venv` path

What changed
============

If that value is defined, use that in `GetPackageDir`

Test plan
=========

With that envvar defined, `upm -p python3-uv` commands should use the envvar-specified path