### PR TITLE
cfg.Project can be nil, which panics

### DIFF
--- a/internal/backends/python/python.go
+++ b/internal/backends/python/python.go
@@ -705,6 +705,10 @@ func makePythonUvBackend() api.LanguageBackend {
 			return nil
 		}
 
+		if cfg.Project == nil {
+			return nil
+		}
+
 		pkgs := map[api.PkgName]api.PkgSpec{}
 
 		for _, dep := range cfg.Project.Dependencies {


### PR DESCRIPTION
Why
===

Surely there must be a way to statically analyze this.

What changed
============

Turns out `cfg.Project` was being accessed without nil check.

Test plan
=========

Manual testing