### PR TITLE
[dependabot] disable for python and node

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,11 +6,13 @@ updates:
     package-ecosystem: "npm"
     schedule:
       interval: "monthly"
+    open-pull-requests-limit: 0
     ignore:
     - dependency-name: "*"
   - directory: "/test-suite"
     package-ecosystem: "pip"
     schedule:
       interval: "monthly"
+    open-pull-requests-limit: 0
     ignore:
     - dependency-name: "*"


### PR DESCRIPTION
Why
===
* We don't use python and node for upm, we use Go
* We're getting reports we don't need to address on dependencies in our test suite.
* It doesn't matter if there is an outdated or insecure dep in our test suite, since we aren't even running python or node code

What changed
===
* Limit dependabot to 0 PRs in pip and npm ecosystems

Test plan
===
* Stop seeing dependabot PRs for node and python
