### PR TITLE
bug/Proactively remove uv detritus

### DIFF
--- a/internal/backends/python/python.go
+++ b/internal/backends/python/python.go
@@ -4,6 +4,7 @@ package python
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -776,6 +777,13 @@ func makePythonUvBackend() api.LanguageBackend {
 			defer span.Finish()
 			// Initalize the specfile if it doesnt exist
 			if !util.Exists("pyproject.toml") {
+				// uv (currently?) creates a "hello.py" on uv init. Ensure it gets deleted before control returns to the user.
+				sampleFileName := "hello.py"
+				if util.Exists(sampleFileName) {
+					// Turns out it didn't exist after all!
+					sampleFileName = ""
+				}
+
 				cmd := []string{"uv", "init", "--no-progress", "--no-readme", "--no-pin-python"}
 
 				if projectName != "" {
@@ -783,6 +791,9 @@ func makePythonUvBackend() api.LanguageBackend {
 				}
 
 				util.RunCmd(cmd)
+				if sampleFileName != "" && util.Exists(sampleFileName) {
+					os.Remove(sampleFileName)
+				}
 			}
 
 			cmd := []string{"uv", "add"}

--- a/internal/backends/python/python.go
+++ b/internal/backends/python/python.go
@@ -779,6 +779,7 @@ func makePythonUvBackend() api.LanguageBackend {
 			if !util.Exists("pyproject.toml") {
 				// uv (currently?) creates a "hello.py" on uv init. Ensure it gets deleted before control returns to the user.
 				sampleFileName := "hello.py"
+				// If the user already _has_ a file called hello.py, do not delete it for them.
 				if util.Exists(sampleFileName) {
 					// Turns out it didn't exist after all!
 					sampleFileName = ""

--- a/internal/backends/python/python.go
+++ b/internal/backends/python/python.go
@@ -776,7 +776,7 @@ func makePythonUvBackend() api.LanguageBackend {
 			defer span.Finish()
 			// Initalize the specfile if it doesnt exist
 			if !util.Exists("pyproject.toml") {
-				cmd := []string{"uv", "init", "--no-progress"}
+				cmd := []string{"uv", "init", "--no-progress", "--no-readme", "--no-pin-python"}
 
 				if projectName != "" {
 					cmd = append(cmd, "--name", projectName)

--- a/internal/backends/python/python.go
+++ b/internal/backends/python/python.go
@@ -781,7 +781,6 @@ func makePythonUvBackend() api.LanguageBackend {
 				sampleFileName := "hello.py"
 				// If the user already _has_ a file called hello.py, do not delete it for them.
 				if util.Exists(sampleFileName) {
-					// Turns out it didn't exist after all!
 					sampleFileName = ""
 				}
 

--- a/internal/backends/python/python.go
+++ b/internal/backends/python/python.go
@@ -4,7 +4,6 @@ package python
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"os"


### PR DESCRIPTION
Why
===

`uv init` creates `README.md`, `hello.py`, and `.python-version` files. These are noisy and don't match the behavior of other python package managers in upm, so let's patch that up.

What changed
============

- Added more flags to `uv init`
- Test for `hello.py` before and after `uv init`. If it gets created through that process, delete it.

Test plan
=========

New agent runs should not have `hello.py`, uv's `README.md`, or `.python-version` files