### PR TITLE
bug/Evict uv if we see requirements.txt

### DIFF
--- a/internal/backends/python/python.go
+++ b/internal/backends/python/python.go
@@ -741,6 +741,12 @@ func makePythonUvBackend() api.LanguageBackend {
 				return false, err
 			}
 
+			// If we see a requirements.txt, let's make sure we don't accidentally
+			// choose uv over pip.
+			if info, err := os.Stat(PythonPipBackend.Specfile); err == nil {
+				return info == nil, nil
+			}
+
 			return cfg.Tool.Poetry == nil, nil
 		},
 		Lockfile: "uv.lock",


### PR DESCRIPTION
Why
===

If a repl has `pyproject.toml` as well as `requirements.txt` we accidentally choose uv over `requirements.txt`.

What changed
============

uv chooses to evict itself if `requirements.txt` exists.

Test plan
=========

Create a `pyproject.toml` alongside `requirements.txt` in a repl. `upm which-language` should return `pip`