### PR TITLE
feat/Adding support for which-language --all

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,6 +1,5 @@
-run = "make && echo \"UPM is built, can be found here: ./cmd/upm/upm\""
-
-modules = ["go-1.20:v2-20230911-b5aa5df"]
+run = "make upm && echo \"UPM is built, can be found here: ./cmd/upm/upm\""
+modules = ["bash", "bun-1.1", "go-1.21", "python-3.12"]
 
 [nix]
-channel = "stable-23_05"
+channel = "stable-24_05"

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -182,6 +182,10 @@ type LanguageBackend struct {
 	// Check to see if we think we can run at all
 	IsAvailable func() bool
 
+	// Check for signs that this backend has either been used or
+	// can be used to query
+	IsActive func() bool
+
 	// List of filename globs that match against files written in
 	// this programming language, e.g. "*.py" for Python. These
 	// should not include any slashes, because they may be matched

--- a/internal/backends/nodejs/nodejs.go
+++ b/internal/backends/nodejs/nodejs.go
@@ -393,10 +393,7 @@ var tsxPathGlobs = []string{
 
 func commonIsActive(lockfile string) bool {
 	_, err := os.Stat(lockfile)
-	if os.IsNotExist(err) {
-		return false
-	}
-	return true
+	return !os.IsNotExist(err)
 }
 
 // NodejsYarnBackend is a UPM backend for Node.js that uses [Yarn](https://yarnpkg.com/).

--- a/internal/backends/nodejs/nodejs.go
+++ b/internal/backends/nodejs/nodejs.go
@@ -391,12 +391,23 @@ var tsxPathGlobs = []string{
 	"*.tsx",
 }
 
+func commonIsActive(lockfile string) bool {
+	_, err := os.Stat(lockfile)
+	if os.IsNotExist(err) {
+		return false
+	}
+	return true
+}
+
 // NodejsYarnBackend is a UPM backend for Node.js that uses [Yarn](https://yarnpkg.com/).
 var NodejsYarnBackend = api.LanguageBackend{
 	Name:             "nodejs-yarn",
 	Specfile:         "package.json",
 	Lockfile:         "yarn.lock",
 	IsAvailable:      yarnIsAvailable,
+	IsActive: func() bool {
+		return commonIsActive("yarn.lock")
+	},
 	FilenamePatterns: nodejsPatterns,
 	Quirks: api.QuirksAddRemoveAlsoLocks |
 		api.QuirksAddRemoveAlsoInstalls |
@@ -481,6 +492,9 @@ var NodejsPNPMBackend = api.LanguageBackend{
 	Specfile:         "package.json",
 	Lockfile:         "pnpm-lock.yaml",
 	IsAvailable:      pnpmIsAvailable,
+	IsActive: func() bool {
+		return commonIsActive("pnpm-lock.yaml")
+	},
 	FilenamePatterns: nodejsPatterns,
 	Quirks: api.QuirksAddRemoveAlsoLocks |
 		api.QuirksAddRemoveAlsoInstalls |
@@ -581,6 +595,9 @@ var NodejsNPMBackend = api.LanguageBackend{
 	Specfile:         "package.json",
 	Lockfile:         "package-lock.json",
 	IsAvailable:      npmIsAvailable,
+	IsActive: func() bool {
+		return commonIsActive("package-lock.json")
+	},
 	FilenamePatterns: nodejsPatterns,
 	Quirks: api.QuirksAddRemoveAlsoLocks |
 		api.QuirksAddRemoveAlsoInstalls |
@@ -670,6 +687,9 @@ var BunBackend = api.LanguageBackend{
 	Specfile:         "package.json",
 	Lockfile:         "bun.lockb",
 	IsAvailable:      bunIsAvailable,
+	IsActive: func() bool {
+		return commonIsActive("bun.lockb")
+	},
 	FilenamePatterns: nodejsPatterns,
 	Quirks: api.QuirksAddRemoveAlsoLocks |
 		api.QuirksAddRemoveAlsoInstalls |

--- a/internal/backends/python/python.go
+++ b/internal/backends/python/python.go
@@ -303,10 +303,7 @@ func commonGuessPackageDir() string {
 
 func commonIsActive(lockfile string) bool {
 	_, err := os.Stat(lockfile)
-	if os.IsNotExist(err) {
-		return false
-	}
-	return true
+	return !os.IsNotExist(err)
 }
 
 var pythonGuessRegexps = util.Regexps([]string{

--- a/internal/backends/python/python.go
+++ b/internal/backends/python/python.go
@@ -301,6 +301,14 @@ func commonGuessPackageDir() string {
 	return ""
 }
 
+func commonIsActive(lockfile string) bool {
+	_, err := os.Stat(lockfile)
+	if os.IsNotExist(err) {
+		return false
+	}
+	return true
+}
+
 var pythonGuessRegexps = util.Regexps([]string{
 	// The (?:.|\\\n) subexpression allows us to
 	// match match multiple lines if
@@ -382,6 +390,9 @@ func makePythonPoetryBackend() api.LanguageBackend {
 		IsAvailable: func() bool {
 			_, err := exec.LookPath("poetry")
 			return err == nil
+		},
+		IsActive: func() bool {
+			return commonIsActive("poetry.lock")
 		},
 		FilenamePatterns: []string{"*.py"},
 		Quirks: api.QuirksAddRemoveAlsoLocks |
@@ -753,6 +764,9 @@ func makePythonUvBackend() api.LanguageBackend {
 		IsAvailable: func() bool {
 			_, err := exec.LookPath("uv")
 			return err == nil
+		},
+		IsActive: func() bool {
+			return commonIsActive("uv.lock")
 		},
 		Alias:                "python-python3-uv",
 		FilenamePatterns:     []string{"*.py"},

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -96,9 +96,12 @@ func DoCLI() {
 		Long:  "Ask which language your project is autodetected as",
 		Args:  cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
-			runWhichLanguage(language)
+			runWhichLanguage(language, all)
 		},
 	}
+	cmdWhichLanguage.Flags().BoolVarP(
+		&all, "all", "a", false, "List all packages for all detected languages",
+	)
 	rootCmd.AddCommand(cmdWhichLanguage)
 
 	cmdListLanguages := &cobra.Command{

--- a/internal/cli/cmds.go
+++ b/internal/cli/cmds.go
@@ -42,9 +42,29 @@ func (s *subroutineSilencer) restore() {
 }
 
 // runWhichLanguage implements 'upm which-language'.
-func runWhichLanguage(language string) {
-	b := backends.GetBackend(context.Background(), language)
-	fmt.Println(b.Name)
+func runWhichLanguage(language string, all bool) {
+	if !all {
+		b := backends.GetBackend(context.Background(), language)
+		fmt.Println(b.Name)
+		return
+	}
+	for _, bi := range backends.GetBackendNames() {
+		if !bi.Available {
+			continue
+		}
+		if language != "" && !strings.Contains(bi.Name, language) {
+			continue
+		}
+
+		b := backends.GetBackend(context.Background(), bi.Name)
+
+		// If we can't determine we are in use, don't report
+		if b.IsActive == nil || !b.IsActive() {
+			continue
+		}
+
+		fmt.Println(b.Name)
+	}
 }
 
 // runListLanguages implements 'upm list-languages'.


### PR DESCRIPTION
Why
===

Determining which languages are currently in play is a useful operation. For example:

```
~/workspace$ ./cmd/upm/upm which-language --all | \
                xargs -I% ./cmd/upm/upm list --all --format json --lang %

[{"name":"click","version":"8.1.7"},{"name":"markupsafe","version":"3.0.2"},{"name":"workspace","version":"0.1.0"},{"name":"blinker","version":"1.8.2"},{"name":"colorama","version":"0.4.6"},{"name":"flask","version":"3.0.3"},{"name":"itsdangerous","version":"2.2.0"},{"name":"jinja2","version":"3.1.4"},{"name":"werkzeug","version":"3.0.6"}]
[{"name":"follow-redirects","version":"1.15.9"},{"name":"@types/node","version":"20.12.14"},{"name":"@types/bun","version":"1.1.12"},{"name":"combined-stream","version":"1.0.8"},{"name":"delayed-stream","version":"1.0.0"},{"name":"form-data","version":"4.0.1"},{"name":"mime-types","version":"2.1.35"},{"name":"proxy-from-env","version":"1.1.0"},{"name":"bun-types","version":"1.1.32"},{"name":"asynckit","version":"0.4.0"},{"name":"axios","version":"1.7.7"},{"name":"mime-db","version":"1.52.0"},{"name":"typescript","version":"5.6.3"},{"name":"undici-types","version":"5.26.5"},{"name":"@types/ws","version":"8.5.12"}]
```

What changed
============

- Added `--all` to `which-language`
- Added `IsActive` to the `api.LanguageBackend` interface and Python/Node backends for now

Test plan
=========

The above command worked