### PR TITLE
Pypi override for z3 theorem prover from Microsoft Research

### DIFF
--- a/internal/backends/python/pypi_map.override.go
+++ b/internal/backends/python/pypi_map.override.go
@@ -21,6 +21,7 @@ var moduleToPypiPackageOverride = map[string][]string{
 	"tensorflow":           append([]string{"tensorflow"}, tf_variants[:]...),        // Avoid suggesting conflicting tensorflow builds
 	"tensorflow-federated": {"tensorflow-federated", "tensorflow-federated-nightly"}, // Avoid suggesting conflicting tensorflow-federated packages
 	"tensorflow1":          {"tensorflow"},                                           // Avoid confusion.
+	"z3":                   {"z3-solver", "z3"},                                      // Popular library from Microsoft Research vs abandoned beta project
 }
 
 /* Proxy packages


### PR DESCRIPTION
Why
===

Resolve a collision between two packages providing `z3`. Giving precedence to the actively maintained project from Microsoft Research.
