### PR TITLE
include download stats in sqlite query

### DIFF
--- a/internal/backends/nodejs/nodejs.go
+++ b/internal/backends/nodejs/nodejs.go
@@ -402,10 +402,10 @@ func commonIsActive(lockfile string) bool {
 
 // NodejsYarnBackend is a UPM backend for Node.js that uses [Yarn](https://yarnpkg.com/).
 var NodejsYarnBackend = api.LanguageBackend{
-	Name:             "nodejs-yarn",
-	Specfile:         "package.json",
-	Lockfile:         "yarn.lock",
-	IsAvailable:      yarnIsAvailable,
+	Name:        "nodejs-yarn",
+	Specfile:    "package.json",
+	Lockfile:    "yarn.lock",
+	IsAvailable: yarnIsAvailable,
 	IsActive: func() bool {
 		return commonIsActive("yarn.lock")
 	},
@@ -489,10 +489,10 @@ var NodejsYarnBackend = api.LanguageBackend{
 
 // NodejsPNPMBackend is a UPM backend for Node.js that uses [pnpm](https://pnpm.io/).
 var NodejsPNPMBackend = api.LanguageBackend{
-	Name:             "nodejs-pnpm",
-	Specfile:         "package.json",
-	Lockfile:         "pnpm-lock.yaml",
-	IsAvailable:      pnpmIsAvailable,
+	Name:        "nodejs-pnpm",
+	Specfile:    "package.json",
+	Lockfile:    "pnpm-lock.yaml",
+	IsAvailable: pnpmIsAvailable,
 	IsActive: func() bool {
 		return commonIsActive("pnpm-lock.yaml")
 	},
@@ -592,10 +592,10 @@ var NodejsPNPMBackend = api.LanguageBackend{
 
 // NodejsNPMBackend is a UPM backend for Node.js that uses [NPM](https://npmjs.com/).
 var NodejsNPMBackend = api.LanguageBackend{
-	Name:             "nodejs-npm",
-	Specfile:         "package.json",
-	Lockfile:         "package-lock.json",
-	IsAvailable:      npmIsAvailable,
+	Name:        "nodejs-npm",
+	Specfile:    "package.json",
+	Lockfile:    "package-lock.json",
+	IsAvailable: npmIsAvailable,
 	IsActive: func() bool {
 		return commonIsActive("package-lock.json")
 	},
@@ -684,10 +684,10 @@ var NodejsNPMBackend = api.LanguageBackend{
 
 // BunBackend is a UPM backend for Node.js that uses [Bun](https://bun.sh/).
 var BunBackend = api.LanguageBackend{
-	Name:             "bun",
-	Specfile:         "package.json",
-	Lockfile:         "bun.lockb",
-	IsAvailable:      bunIsAvailable,
+	Name:        "bun",
+	Specfile:    "package.json",
+	Lockfile:    "bun.lockb",
+	IsAvailable: bunIsAvailable,
 	IsActive: func() bool {
 		return commonIsActive("bun.lockb")
 	},

--- a/internal/backends/python/gen_pypi_map/db_gen.go
+++ b/internal/backends/python/gen_pypi_map/db_gen.go
@@ -92,7 +92,8 @@ func GenerateDB(pkg string, outputFilePath string, cache map[string]PackageInfo,
 			stmt.Close()
 
 			stmt, err = db.Prepare(`
-			insert into pypi_packages values (?, ?, ?)
+			insert into pypi_packages (package_name, module_list, download_count)
+			values (?, ?, ?)
 			on conflict (package_name)
 			do update set
 				module_list = excluded.module_list;

--- a/internal/backends/python/gen_pypi_map/db_gen.go
+++ b/internal/backends/python/gen_pypi_map/db_gen.go
@@ -64,7 +64,7 @@ func GenerateDB(pkg string, outputFilePath string, cache map[string]PackageInfo,
 	}
 	_, err = db.Exec(`
 	create table module_to_pypi_package (module_name text primary key, guess text, reason text);
-	create table pypi_packages (package_name text primary key, module_list text);
+	create table pypi_packages (package_name text primary key, module_list text, download_count number);
 	`)
 	if err != nil {
 		return err
@@ -92,7 +92,7 @@ func GenerateDB(pkg string, outputFilePath string, cache map[string]PackageInfo,
 			stmt.Close()
 
 			stmt, err = db.Prepare(`
-			insert into pypi_packages values (?, ?)
+			insert into pypi_packages values (?, ?, ?)
 			on conflict (package_name)
 			do update set
 				module_list = excluded.module_list;
@@ -100,7 +100,9 @@ func GenerateDB(pkg string, outputFilePath string, cache map[string]PackageInfo,
 			if err != nil {
 				return err
 			}
-			_, err = stmt.Exec(guess.Name, strings.Join(guess.Modules, ","))
+
+			downloadCount := downloadStats[normalizePackageName(guess.Name)]
+			_, err = stmt.Exec(guess.Name, strings.Join(guess.Modules, ","), downloadCount)
 			if err != nil {
 				return fmt.Errorf("%s on %s", err.Error(), guess.Name)
 			}

--- a/internal/backends/python/pypi_map.go
+++ b/internal/backends/python/pypi_map.go
@@ -9,6 +9,7 @@ import (
 	"database/sql"
 	"fmt"
 	"os"
+	"regexp"
 
 	"github.com/replit/upm/internal/api"
 
@@ -64,12 +65,14 @@ func (p *PypiMap) ModuleToPackage(moduleName string) (string, bool) {
 }
 
 func (p *PypiMap) QueryToResults(query string) ([]api.PkgInfo, error) {
+	not_letter := regexp.MustCompile("[^a-zA-Z0-9]")
+	percent_query := string(not_letter.ReplaceAll([]byte(query), []byte("%")))
 	stmt, err := p.db.Prepare("select package_name from pypi_packages where package_name like ('%' || ? || '%') order by download_count desc")
 	if err != nil {
 		return nil, err
 	}
 	defer stmt.Close()
-	rows, err := stmt.Query(query)
+	rows, err := stmt.Query(percent_query)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/backends/python/pypi_map.go
+++ b/internal/backends/python/pypi_map.go
@@ -9,7 +9,6 @@ import (
 	"database/sql"
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/replit/upm/internal/api"
 
@@ -62,28 +61,6 @@ func (p *PypiMap) ModuleToPackage(moduleName string) (string, bool) {
 		return "", false
 	}
 	return guess, true
-}
-
-func (p *PypiMap) PackageToModules(packageName string) ([]string, bool) {
-	stmt, err := p.db.Prepare("select module_list from pypi_packages where package_name = ?")
-	if err != nil {
-		return nil, false
-	}
-	defer stmt.Close()
-	rows, err := stmt.Query(packageName)
-	if err != nil {
-		return nil, false
-	}
-	defer rows.Close()
-	if !rows.Next() {
-		return nil, false
-	}
-	var moduleList string
-	err = rows.Scan(&moduleList)
-	if err != nil {
-		return nil, false
-	}
-	return strings.Split(moduleList, ","), true
 }
 
 func (p *PypiMap) QueryToResults(query string) ([]api.PkgInfo, error) {

--- a/internal/backends/python/pypi_map.go
+++ b/internal/backends/python/pypi_map.go
@@ -87,7 +87,7 @@ func (p *PypiMap) PackageToModules(packageName string) ([]string, bool) {
 }
 
 func (p *PypiMap) QueryToResults(query string) ([]api.PkgInfo, error) {
-	stmt, err := p.db.Prepare("select package_name from pypi_packages where package_name like ('%' || ? || '%')")
+	stmt, err := p.db.Prepare("select package_name from pypi_packages where package_name like ('%' || ? || '%') order by download_count desc")
 	if err != nil {
 		return nil, err
 	}

--- a/test-suite/utils/upm.go
+++ b/test-suite/utils/upm.go
@@ -323,13 +323,13 @@ func (bt *BackendT) UpmSearch(query, expectName string) {
 	)
 
 	if exitError, ok := err.(*exec.ExitError); ok {
-			if exitError.ExitCode() == 13 {
-				duration := time.Duration(float32(10 * time.Second) * rand.Float32())
-				bt.Log("Protocol error in 'search', retrying in %v", duration)
-				time.Sleep(duration)
-				bt.UpmSearch(query, expectName)
-				return
-			}
+		if exitError.ExitCode() == 13 {
+			duration := time.Duration(float32(10*time.Second) * rand.Float32())
+			bt.Log("Protocol error in 'search', retrying in %v", duration)
+			time.Sleep(duration)
+			bt.UpmSearch(query, expectName)
+			return
+		}
 	}
 
 	if err != nil {


### PR DESCRIPTION
Why
===

In an attempt to make the fallback a _little_ nicer without ballooning the database too much, let's include `download_count` so we can impose some sort of sensible ordering.

I added some heuristics to the query builder to make it feel a little better to use with imprecise queries.

What changed
============

Add ordering sqlite fallback by `download_count`

Test plan
=========

CI