### PR TITLE
[python] Fix bug parsing extras

### DIFF
--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -20,8 +20,9 @@ func (n PkgName) HasPrefix(other PkgName) bool {
 }
 
 type PkgCoordinates struct {
-	Name string
-	Spec PkgSpec
+	Name  string
+	Spec  PkgSpec
+	Extra any
 }
 
 // PkgSpec represents a package version constraint, e.g. "^1.1" or ">=

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -263,7 +263,7 @@ type LanguageBackend struct {
 	// it does not exist already.
 	//
 	// This field is mandatory.
-	Add func(context.Context, map[PkgName]PkgSpec, string)
+	Add func(context.Context, map[PkgName]PkgCoordinates, string)
 
 	// Remove packages from the specfile. The map is guaranteed to
 	// have at least one package, and all of the packages are

--- a/internal/backends/dart/dart.go
+++ b/internal/backends/dart/dart.go
@@ -257,7 +257,7 @@ func readSpecFile() dartPubspecYaml {
 	return specs
 }
 
-func dartAdd(ctx context.Context, pkgs map[api.PkgName]api.PkgSpec, projectName string) {
+func dartAdd(ctx context.Context, pkgs map[api.PkgName]api.PkgCoordinates, projectName string) {
 	//nolint:ineffassign,wastedassign,staticcheck
 	span, ctx := tracer.StartSpanFromContext(ctx, "dartAdd")
 	defer span.Finish()
@@ -267,10 +267,10 @@ func dartAdd(ctx context.Context, pkgs map[api.PkgName]api.PkgSpec, projectName 
 
 	specs := readSpecFile()
 
-	for name, spec := range pkgs {
+	for name, coords := range pkgs {
 		arg := string(name)
-		if spec != "" {
-			specs.Dependencies[arg] = string(spec)
+		if coords.Spec != "" {
+			specs.Dependencies[arg] = string(coords.Spec)
 		} else {
 			specs.Dependencies[arg] = nil
 		}

--- a/internal/backends/dotnet/dotnet.go
+++ b/internal/backends/dotnet/dotnet.go
@@ -25,7 +25,7 @@ var DotNetBackend = api.LanguageBackend{
 	Remove: func(ctx context.Context, pkgs map[api.PkgName]bool) {
 		removePackages(ctx, pkgs, findSpecFile(), util.RunCmd)
 	},
-	Add: func(ctx context.Context, pkgs map[api.PkgName]api.PkgSpec, projectName string) {
+	Add: func(ctx context.Context, pkgs map[api.PkgName]api.PkgCoordinates, projectName string) {
 		addPackages(ctx, pkgs, projectName, util.RunCmd)
 	},
 	Search:       search,

--- a/internal/backends/dotnet/dotnet_cli.go
+++ b/internal/backends/dotnet/dotnet_cli.go
@@ -19,14 +19,14 @@ func removePackages(ctx context.Context, pkgs map[api.PkgName]bool, specFileName
 }
 
 // adds packages using dotnet command which automatically updates lock files
-func addPackages(ctx context.Context, pkgs map[api.PkgName]api.PkgSpec, projectName string, cmdRunner func([]string)) {
+func addPackages(ctx context.Context, pkgs map[api.PkgName]api.PkgCoordinates, projectName string, cmdRunner func([]string)) {
 	//nolint:ineffassign,wastedassign,staticcheck
 	span, ctx := tracer.StartSpanFromContext(ctx, "dotnet add package")
 	defer span.Finish()
-	for packageName, spec := range pkgs {
+	for packageName, coords := range pkgs {
 		command := []string{"dotnet", "add", "package", string(packageName)}
-		if string(spec) != "" {
-			command = append(command, "--version", string(spec))
+		if string(coords.Spec) != "" {
+			command = append(command, "--version", string(coords.Spec))
 		}
 		cmdRunner(command)
 	}

--- a/internal/backends/dotnet/dotnet_cli_test.go
+++ b/internal/backends/dotnet/dotnet_cli_test.go
@@ -14,7 +14,7 @@ func TestAddPackages(t *testing.T) {
 		cmds = append(cmds, strings.Join(cmd, " "))
 	}
 
-	addPackages(context.Background(), map[api.PkgName]api.PkgSpec{"package": "1.0"}, "", cmdRunner)
+	addPackages(context.Background(), map[api.PkgName]api.PkgCoordinates{"package": {Name: "package", Spec: "1.0"}}, "", cmdRunner)
 
 	if len(cmds) != 1 {
 		t.Errorf("Expected one command but got %q", len(cmds))
@@ -31,7 +31,7 @@ func TestAddPackagesWithoutVersion(t *testing.T) {
 		cmds = append(cmds, strings.Join(cmd, " "))
 	}
 
-	addPackages(context.Background(), map[api.PkgName]api.PkgSpec{"package": ""}, "", cmdRunner)
+	addPackages(context.Background(), map[api.PkgName]api.PkgCoordinates{"package": {Name: "package"}}, "", cmdRunner)
 
 	if len(cmds) != 1 {
 		t.Errorf("Expected one command but got %q", len(cmds))

--- a/internal/backends/elisp/elisp.go
+++ b/internal/backends/elisp/elisp.go
@@ -87,7 +87,7 @@ var ElispBackend = api.LanguageBackend{
 		}
 		return info
 	},
-	Add: func(ctx context.Context, pkgs map[api.PkgName]api.PkgSpec, projectName string) {
+	Add: func(ctx context.Context, pkgs map[api.PkgName]api.PkgCoordinates, projectName string) {
 		//nolint:ineffassign,wastedassign,staticcheck
 		span, ctx := tracer.StartSpanFromContext(ctx, "elisp add")
 		defer span.Finish()
@@ -110,10 +110,10 @@ var ElispBackend = api.LanguageBackend{
 			contents += "\n"
 		}
 
-		for name, spec := range pkgs {
+		for name, coords := range pkgs {
 			contents += fmt.Sprintf(`(depends-on "%s"`, name)
-			if spec != "" {
-				contents += fmt.Sprintf(" %s", spec)
+			if coords.Spec != "" {
+				contents += fmt.Sprintf(" %s", coords.Spec)
 			}
 			contents += ")\n"
 		}

--- a/internal/backends/java/java.go
+++ b/internal/backends/java/java.go
@@ -121,7 +121,7 @@ func isAvailable() bool {
 	return err == nil
 }
 
-func addPackages(ctx context.Context, pkgs map[api.PkgName]api.PkgSpec, projectName string) {
+func addPackages(ctx context.Context, pkgs map[api.PkgName]api.PkgCoordinates, projectName string) {
 	//nolint:ineffassign,wastedassign,staticcheck
 	span, ctx := tracer.StartSpanFromContext(ctx, "Java add package")
 	defer span.Finish()
@@ -136,7 +136,8 @@ func addPackages(ctx context.Context, pkgs map[api.PkgName]api.PkgSpec, projectN
 	}
 
 	newDependencies := []Dependency{}
-	for pkgName, pkgSpec := range pkgs {
+	for pkgName, coords := range pkgs {
+		pkgSpec := coords.Spec
 		submatches := pkgNameRegexp.FindStringSubmatch(string(pkgName))
 		if nil == submatches {
 			util.DieConsistency(

--- a/internal/backends/nodejs/nodejs.go
+++ b/internal/backends/nodejs/nodejs.go
@@ -411,7 +411,7 @@ var NodejsYarnBackend = api.LanguageBackend{
 	},
 	Search: nodejsSearch,
 	Info:   nodejsInfo,
-	Add: func(ctx context.Context, pkgs map[api.PkgName]api.PkgSpec, projectName string) {
+	Add: func(ctx context.Context, pkgs map[api.PkgName]api.PkgCoordinates, projectName string) {
 		//nolint:ineffassign,wastedassign,staticcheck
 		span, ctx := tracer.StartSpanFromContext(ctx, "yarn (init) add")
 		defer span.Finish()
@@ -419,16 +419,17 @@ var NodejsYarnBackend = api.LanguageBackend{
 			util.RunCmd([]string{"yarn", "init", "-y"})
 		}
 		cmd := []string{"yarn", "add"}
-		for name, spec := range pkgs {
+		for name, coords := range pkgs {
 			name := string(name)
 			if found, ok := moduleToYarnpkgPackageAliases[name]; ok {
 				delete(pkgs, api.PkgName(name))
 				name = found
-				pkgs[api.PkgName(name)] = api.PkgSpec(spec)
+				coords.Name = found
+				pkgs[api.PkgName(name)] = coords
 			}
 			arg := name
-			if spec != "" {
-				arg += "@" + string(spec)
+			if coords.Spec != "" {
+				arg += "@" + string(coords.Spec)
 			}
 			cmd = append(cmd, arg)
 		}
@@ -497,7 +498,7 @@ var NodejsPNPMBackend = api.LanguageBackend{
 	},
 	Search: nodejsSearch,
 	Info:   nodejsInfo,
-	Add: func(ctx context.Context, pkgs map[api.PkgName]api.PkgSpec, projectName string) {
+	Add: func(ctx context.Context, pkgs map[api.PkgName]api.PkgCoordinates, projectName string) {
 		//nolint:ineffassign,wastedassign,staticcheck
 		span, ctx := tracer.StartSpanFromContext(ctx, "pnpm (init) add")
 		defer span.Finish()
@@ -505,16 +506,17 @@ var NodejsPNPMBackend = api.LanguageBackend{
 			util.RunCmd([]string{"pnpm", "init"})
 		}
 		cmd := []string{"pnpm", "add"}
-		for name, spec := range pkgs {
+		for name, coords := range pkgs {
 			name := string(name)
 			if found, ok := moduleToNpmjsPackageAliases[name]; ok {
 				delete(pkgs, api.PkgName(name))
 				name = found
-				pkgs[api.PkgName(name)] = api.PkgSpec(spec)
+				coords.Name = found
+				pkgs[api.PkgName(name)] = coords
 			}
 			arg := name
-			if spec != "" {
-				arg += "@" + string(spec)
+			if coords.Spec != "" {
+				arg += "@" + string(coords.Spec)
 			}
 			cmd = append(cmd, arg)
 		}
@@ -600,7 +602,7 @@ var NodejsNPMBackend = api.LanguageBackend{
 	},
 	Search: nodejsSearch,
 	Info:   nodejsInfo,
-	Add: func(ctx context.Context, pkgs map[api.PkgName]api.PkgSpec, projectName string) {
+	Add: func(ctx context.Context, pkgs map[api.PkgName]api.PkgCoordinates, projectName string) {
 		//nolint:ineffassign,wastedassign,staticcheck
 		span, ctx := tracer.StartSpanFromContext(ctx, "npm (init) install")
 		defer span.Finish()
@@ -608,16 +610,17 @@ var NodejsNPMBackend = api.LanguageBackend{
 			util.RunCmd([]string{"npm", "init", "-y"})
 		}
 		cmd := []string{"npm", "install"}
-		for name, spec := range pkgs {
+		for name, coords := range pkgs {
 			name := string(name)
 			if found, ok := moduleToNpmjsPackageAliases[name]; ok {
 				delete(pkgs, api.PkgName(name))
 				name = found
-				pkgs[api.PkgName(name)] = api.PkgSpec(spec)
+				coords.Name = found
+				pkgs[api.PkgName(name)] = coords
 			}
 			arg := name
-			if spec != "" {
-				arg += "@" + string(spec)
+			if coords.Spec != "" {
+				arg += "@" + string(coords.Spec)
 			}
 			cmd = append(cmd, arg)
 		}
@@ -692,7 +695,7 @@ var BunBackend = api.LanguageBackend{
 	},
 	Search: nodejsSearch,
 	Info:   nodejsInfo,
-	Add: func(ctx context.Context, pkgs map[api.PkgName]api.PkgSpec, projectName string) {
+	Add: func(ctx context.Context, pkgs map[api.PkgName]api.PkgCoordinates, projectName string) {
 		//nolint:ineffassign,wastedassign,staticcheck
 		span, ctx := tracer.StartSpanFromContext(ctx, "bun (init) add")
 		defer span.Finish()
@@ -701,16 +704,17 @@ var BunBackend = api.LanguageBackend{
 			util.RunCmd([]string{"bun", "init", "-y"})
 		}
 		cmd := []string{"bun", "add"}
-		for name, spec := range pkgs {
+		for name, coords := range pkgs {
 			name := string(name)
 			if found, ok := moduleToNpmjsPackageAliases[name]; ok {
 				delete(pkgs, api.PkgName(name))
 				name = found
-				pkgs[api.PkgName(name)] = api.PkgSpec(spec)
+				coords.Name = found
+				pkgs[api.PkgName(name)] = coords
 			}
 			arg := name
-			if spec != "" {
-				arg += "@" + string(spec)
+			if coords.Spec != "" {
+				arg += "@" + string(coords.Spec)
 			}
 			cmd = append(cmd, arg)
 		}

--- a/internal/backends/php/php.go
+++ b/internal/backends/php/php.go
@@ -241,16 +241,16 @@ var PhpComposerBackend = api.LanguageBackend{
 	},
 	Search: search,
 	Info:   info,
-	Add: func(ctx context.Context, pkgs map[api.PkgName]api.PkgSpec, projectVendorName string) {
+	Add: func(ctx context.Context, pkgs map[api.PkgName]api.PkgCoordinates, projectVendorName string) {
 		//nolint:ineffassign,wastedassign,staticcheck
 		span, ctx := tracer.StartSpanFromContext(ctx, "composer require")
 		defer span.Finish()
 		cmd := []string{"composer", "require"}
 
-		for name, spec := range pkgs {
+		for name, coords := range pkgs {
 			arg := string(name)
-			if spec != "" {
-				arg += ":" + string(spec)
+			if coords.Spec != "" {
+				arg += ":" + string(coords.Spec)
 			}
 			cmd = append(cmd, arg)
 		}

--- a/internal/backends/python/pypi_map.go
+++ b/internal/backends/python/pypi_map.go
@@ -92,8 +92,8 @@ func (p *PypiMap) QueryToResults(query string) ([]api.PkgInfo, error) {
 			return nil, err
 		}
 		packageNames = append(packageNames, api.PkgInfo{
-			Name: packageName,
-			Version: version,
+			Name:        packageName,
+			Version:     version,
 			Description: summary,
 		})
 	}

--- a/internal/backends/python/python.go
+++ b/internal/backends/python/python.go
@@ -115,7 +115,7 @@ type uvLock struct {
 func pep440Join(name api.PkgName, spec api.PkgSpec) string {
 	if spec == "" {
 		return string(name)
-	} else if matchSpecOnly.Match([]byte(spec)) {
+	} else if MatchSpecOnly.Match([]byte(spec)) {
 		return string(name) + string(spec)
 	}
 	// We did not match the version range separator in the spec, so we got
@@ -146,10 +146,10 @@ func normalizePackageArgs(args []string) map[api.PkgName]api.PkgCoordinates {
 		var rawName string
 		var name api.PkgName
 		var spec api.PkgSpec
-		if found := matchPackageAndSpec.FindSubmatch([]byte(arg)); len(found) > 0 {
-			rawName = string(found[1])
+		if found := MatchPackageAndSpec.FindSubmatch([]byte(arg)); len(found) > 0 {
+			rawName = string(found[MatchPackageAndSpecIndexName])
 			name = api.PkgName(rawName)
-			spec = api.PkgSpec(string(found[2]))
+			spec = api.PkgSpec(string(found[MatchPackageAndSpecIndexVersion]))
 		} else {
 			split := strings.SplitN(arg, " ", 2)
 			rawName = split[0]
@@ -158,7 +158,7 @@ func normalizePackageArgs(args []string) map[api.PkgName]api.PkgCoordinates {
 				specStr := strings.TrimSpace(split[1])
 
 				if specStr != "" {
-					if offset := matchPep440VersionComponent.FindIndex([]byte(spec)); len(offset) == 0 {
+					if offset := MatchPep440VersionComponent.FindIndex([]byte(spec)); len(offset) == 0 {
 						spec = api.PkgSpec("==" + specStr)
 					} else {
 						spec = api.PkgSpec(specStr)
@@ -610,9 +610,9 @@ func makePythonPipBackend() api.LanguageBackend {
 			var toAppend []string
 			for _, canonicalSpec := range strings.Split(string(outputB), "\n") {
 				var name api.PkgName
-				matches := matchPackageAndSpec.FindSubmatch(([]byte)(canonicalSpec))
-				if len(matches) > 0 {
-					name = normalizePackageName(api.PkgName(string(matches[1])))
+				matches := MatchPackageAndSpec.FindSubmatch(([]byte)(canonicalSpec))
+				if len(matches) >= MatchPackageAndSpecIndexName {
+					name = normalizePackageName(api.PkgName(string(matches[MatchPackageAndSpecIndexName])))
 					if rawName, ok := normalizedPkgs[name]; ok {
 						// We've meticulously maintained the pkgspec from the CLI args, if specified,
 						// so we don't clobber it with pip freeze's output of "==="
@@ -727,13 +727,13 @@ func makePythonUvBackend() api.LanguageBackend {
 			var name *api.PkgName
 			var spec *api.PkgSpec
 
-			matches := matchPackageAndSpec.FindSubmatch([]byte(dep))
-			if len(matches) > 1 {
-				_name := api.PkgName(string(matches[1]))
+			matches := MatchPackageAndSpec.FindSubmatch([]byte(dep))
+			if len(matches) >= MatchPackageAndSpecIndexName {
+				_name := api.PkgName(string(matches[MatchPackageAndSpecIndexName]))
 				name = &_name
 			}
-			if len(matches) > 2 {
-				_spec := api.PkgSpec(string(matches[2]))
+			if len(matches) >= MatchPackageAndSpecIndexVersion {
+				_spec := api.PkgSpec(string(matches[MatchPackageAndSpecIndexVersion]))
 				spec = &_spec
 			} else {
 				_spec := api.PkgSpec("")

--- a/internal/backends/python/python.go
+++ b/internal/backends/python/python.go
@@ -142,7 +142,6 @@ func normalizeSpec(spec interface{}) string {
 
 func normalizePackageArgs(args []string) map[api.PkgName]api.PkgCoordinates {
 	pkgs := make(map[api.PkgName]api.PkgCoordinates)
-	versionComponent := regexp.MustCompile(pep440VersionComponent)
 	for _, arg := range args {
 		var rawName string
 		var name api.PkgName
@@ -159,7 +158,7 @@ func normalizePackageArgs(args []string) map[api.PkgName]api.PkgCoordinates {
 				specStr := strings.TrimSpace(split[1])
 
 				if specStr != "" {
-					if offset := versionComponent.FindIndex([]byte(spec)); len(offset) == 0 {
+					if offset := matchPep440VersionComponent.FindIndex([]byte(spec)); len(offset) == 0 {
 						spec = api.PkgSpec("==" + specStr)
 					} else {
 						spec = api.PkgSpec(specStr)

--- a/internal/backends/python/python.go
+++ b/internal/backends/python/python.go
@@ -112,15 +112,15 @@ type uvLock struct {
 	} `toml:"package"`
 }
 
-func pep440Join(name api.PkgName, spec api.PkgSpec) string {
-	if spec == "" {
-		return string(name)
-	} else if MatchSpecOnly.Match([]byte(spec)) {
-		return string(name) + string(spec)
+func pep440Join(coords api.PkgCoordinates) string {
+	if coords.Spec == "" {
+		return string(coords.Name)
+	} else if MatchSpecOnly.Match([]byte(coords.Spec)) {
+		return string(coords.Name) + string(coords.Spec)
 	}
 	// We did not match the version range separator in the spec, so we got
 	// something like "foo 1.2.3", we need to return "foo==1.2.3"
-	return string(name) + "==" + string(spec)
+	return string(coords.Name) + "==" + string(coords.Spec)
 }
 
 // normalizeSpec returns the version string from a Poetry spec, or the
@@ -463,7 +463,7 @@ func makePythonPoetryBackend() api.LanguageBackend {
 				// Poetry that can't be worked around.
 				// It looks like that bug might be
 				// fixed in the 1.0 release though :/
-				cmd = append(cmd, pep440Join(name, coords.Spec))
+				cmd = append(cmd, pep440Join(coords))
 			}
 			util.RunCmd(cmd)
 		},
@@ -586,7 +586,7 @@ func makePythonPipBackend() api.LanguageBackend {
 					pkgs[name] = coords
 				}
 
-				cmd = append(cmd, pep440Join(name, coords.Spec))
+				cmd = append(cmd, pep440Join(coords))
 			}
 			// Run install
 			util.RunCmd(cmd)
@@ -616,7 +616,7 @@ func makePythonPipBackend() api.LanguageBackend {
 					if rawName, ok := normalizedPkgs[name]; ok {
 						// We've meticulously maintained the pkgspec from the CLI args, if specified,
 						// so we don't clobber it with pip freeze's output of "==="
-						toAppend = append(toAppend, pep440Join(name, pkgs[rawName].Spec)) // TODO: Just promote coordinates
+						toAppend = append(toAppend, pep440Join(pkgs[rawName]))
 					}
 				}
 			}
@@ -825,7 +825,7 @@ func makePythonUvBackend() api.LanguageBackend {
 					pkgs[api.PkgName(name)] = coords
 				}
 
-				cmd = append(cmd, pep440Join(name, coords.Spec))
+				cmd = append(cmd, pep440Join(coords))
 			}
 			util.RunCmd(cmd)
 		},

--- a/internal/backends/python/requirements.go
+++ b/internal/backends/python/requirements.go
@@ -23,9 +23,10 @@ var pep440VersionSpec = pep440VersionComponent + `(?:\s*,\s*` + pep440VersionCom
 var extrasSpec = `\[` + pep345Name + `(?:\s*,\s*` + pep345Name + `)*\]`
 var MatchEggComponent = regexp.MustCompile(`(?i)\begg=(` + pep345Name + `)(?:$|[^A-Z0-9])`)
 var MatchEggComponentIndexEgg = 1
-var MatchPackageAndSpec = regexp.MustCompile(`(?i)^\s*(` + pep345Name + `)\s*` + `((?:` + extrasSpec + `)?\s*(?:` + pep440VersionSpec + `)?)?\s*$`)
+var MatchPackageAndSpec = regexp.MustCompile(`(?i)^\s*(` + pep345Name + `)\s*(` + extrasSpec + `)?\s*(` + pep440VersionSpec + `)?\s*$`)
 var MatchPackageAndSpecIndexName = 1
-var MatchPackageAndSpecIndexVersion = 2
+var MatchPackageAndSpecIndexExtras = 2
+var MatchPackageAndSpecIndexVersion = 3
 var MatchPep440VersionComponent = regexp.MustCompile(pep440VersionComponent)
 var MatchSpecOnly = regexp.MustCompile(`^` + pep440VersionSpec + `$`)
 

--- a/internal/backends/python/requirements.go
+++ b/internal/backends/python/requirements.go
@@ -20,7 +20,7 @@ import (
 var pep345Name = `(?:[A-Z0-9]|[A-Z0-9][A-Z0-9._-]*[A-Z0-9])`
 var pep440VersionComponent = `(?:(?:~=|!=|===|==|>=|<=|>|<)\s*[^, ]+)`
 var pep440VersionSpec = pep440VersionComponent + `(?:\s*,\s*` + pep440VersionComponent + `)*`
-var extrasSpec = `\[(` + pep345Name + `(?:\s*,\s*` + pep345Name + `)*)\]`
+var extrasSpec = `\[` + pep345Name + `(?:\s*,\s*` + pep345Name + `)*\]`
 var MatchEggComponent = regexp.MustCompile(`(?i)\begg=(` + pep345Name + `)(?:$|[^A-Z0-9])`)
 var MatchEggComponentIndexEgg = 1
 var MatchPackageAndSpec = regexp.MustCompile(`(?i)^\s*(` + pep345Name + `)\s*` + `((?:` + extrasSpec + `)?\s*(?:` + pep440VersionSpec + `)?)?\s*$`)

--- a/internal/backends/python/requirements.go
+++ b/internal/backends/python/requirements.go
@@ -20,10 +20,11 @@ import (
 var pep345Name = `(?:[A-Z0-9]|[A-Z0-9][A-Z0-9._-]*[A-Z0-9])`
 var pep440VersionComponent = `(?:(?:~=|!=|===|==|>=|<=|>|<)\s*[^, ]+)`
 var pep440VersionSpec = pep440VersionComponent + `(?:\s*,\s*` + pep440VersionComponent + `)*`
-var matchSpecOnly = regexp.MustCompile(`^` + pep440VersionSpec + `$`)
 var extrasSpec = `\[(` + pep345Name + `(?:\s*,\s*` + pep345Name + `)*)\]`
-var matchPackageAndSpec = regexp.MustCompile(`(?i)^\s*(` + pep345Name + `)\s*` + `((?:` + extrasSpec + `)?\s*(?:` + pep440VersionSpec + `)?)?\s*$`)
 var matchEggComponent = regexp.MustCompile(`(?i)\begg=(` + pep345Name + `)(?:$|[^A-Z0-9])`)
+var matchPackageAndSpec = regexp.MustCompile(`(?i)^\s*(` + pep345Name + `)\s*` + `((?:` + extrasSpec + `)?\s*(?:` + pep440VersionSpec + `)?)?\s*$`)
+var matchPep440VersionComponent = regexp.MustCompile(pep440VersionComponent)
+var matchSpecOnly = regexp.MustCompile(`^` + pep440VersionSpec + `$`)
 
 // Global options:
 //

--- a/internal/backends/python/requirements.go
+++ b/internal/backends/python/requirements.go
@@ -21,10 +21,13 @@ var pep345Name = `(?:[A-Z0-9]|[A-Z0-9][A-Z0-9._-]*[A-Z0-9])`
 var pep440VersionComponent = `(?:(?:~=|!=|===|==|>=|<=|>|<)\s*[^, ]+)`
 var pep440VersionSpec = pep440VersionComponent + `(?:\s*,\s*` + pep440VersionComponent + `)*`
 var extrasSpec = `\[(` + pep345Name + `(?:\s*,\s*` + pep345Name + `)*)\]`
-var matchEggComponent = regexp.MustCompile(`(?i)\begg=(` + pep345Name + `)(?:$|[^A-Z0-9])`)
-var matchPackageAndSpec = regexp.MustCompile(`(?i)^\s*(` + pep345Name + `)\s*` + `((?:` + extrasSpec + `)?\s*(?:` + pep440VersionSpec + `)?)?\s*$`)
-var matchPep440VersionComponent = regexp.MustCompile(pep440VersionComponent)
-var matchSpecOnly = regexp.MustCompile(`^` + pep440VersionSpec + `$`)
+var MatchEggComponent = regexp.MustCompile(`(?i)\begg=(` + pep345Name + `)(?:$|[^A-Z0-9])`)
+var MatchEggComponentIndexEgg = 1
+var MatchPackageAndSpec = regexp.MustCompile(`(?i)^\s*(` + pep345Name + `)\s*` + `((?:` + extrasSpec + `)?\s*(?:` + pep440VersionSpec + `)?)?\s*$`)
+var MatchPackageAndSpecIndexName = 1
+var MatchPackageAndSpecIndexVersion = 2
+var MatchPep440VersionComponent = regexp.MustCompile(pep440VersionComponent)
+var MatchSpecOnly = regexp.MustCompile(`^` + pep440VersionSpec + `$`)
 
 // Global options:
 //
@@ -58,14 +61,14 @@ func findPackage(line string) (*api.PkgName, *api.PkgSpec, bool) {
 
 	var found bool
 
-	matches := matchPackageAndSpec.FindSubmatch([]byte(line))
-	if len(matches) > 1 {
-		_name := api.PkgName(string(matches[1]))
+	matches := MatchPackageAndSpec.FindSubmatch([]byte(line))
+	if len(matches) >= MatchPackageAndSpecIndexName {
+		_name := api.PkgName(string(matches[MatchPackageAndSpecIndexName]))
 		name = &_name
 		found = true
 	}
-	if len(matches) > 2 {
-		_spec := api.PkgSpec(string(matches[2]))
+	if len(matches) >= MatchPackageAndSpecIndexVersion {
+		_spec := api.PkgSpec(string(matches[MatchPackageAndSpecIndexVersion]))
 		spec = &_spec
 	}
 	return name, spec, found
@@ -122,9 +125,9 @@ func recurseRequirementsTxt(depth int, path string, sofar map[api.PkgName]api.Pk
 			// from inserting it into requirements.txt, which would then cause a conflict
 			// on the next run.
 			if parts[0] == "-e" || parts[0] == "--editable" {
-				matches := matchEggComponent.FindSubmatch([]byte(line))
-				if len(matches) > 1 {
-					sofar[api.PkgName(string(matches[1]))] = ""
+				matches := MatchEggComponent.FindSubmatch([]byte(line))
+				if len(matches) >= MatchEggComponentIndexEgg {
+					sofar[api.PkgName(string(matches[MatchEggComponentIndexEgg]))] = ""
 				}
 			}
 		}

--- a/internal/backends/rlang/rlang.go
+++ b/internal/backends/rlang/rlang.go
@@ -130,11 +130,11 @@ var RlangBackend = api.LanguageBackend{
 
 		return api.PkgInfo{}
 	},
-	Add: func(ctx context.Context, packages map[api.PkgName]api.PkgSpec, projectName string) {
-		for name, info := range packages {
+	Add: func(ctx context.Context, packages map[api.PkgName]api.PkgCoordinates, projectName string) {
+		for name, coords := range packages {
 			RAdd(ctx, RPackage{
 				Name:    string(name),
-				Version: string(info),
+				Version: string(coords.Spec),
 			})
 		}
 	},

--- a/internal/backends/ruby/ruby.go
+++ b/internal/backends/ruby/ruby.go
@@ -177,7 +177,7 @@ var RubyBackend = api.LanguageBackend{
 			Dependencies:     deps,
 		}
 	},
-	Add: func(ctx context.Context, pkgs map[api.PkgName]api.PkgSpec, projectName string) {
+	Add: func(ctx context.Context, pkgs map[api.PkgName]api.PkgCoordinates, projectName string) {
 		//nolint:ineffassign,wastedassign,staticcheck
 		span, ctx := tracer.StartSpanFromContext(ctx, "bundle (init) add")
 		defer span.Finish()
@@ -185,8 +185,8 @@ var RubyBackend = api.LanguageBackend{
 			util.RunCmd([]string{"bundle", "init"})
 		}
 		args := []string{}
-		for name, spec := range pkgs {
-			if spec == "" {
+		for name, coords := range pkgs {
+			if coords.Spec == "" {
 				args = append(args, string(name))
 			}
 		}
@@ -197,10 +197,10 @@ var RubyBackend = api.LanguageBackend{
 			util.RunCmd(append([]string{
 				"bundle", "add", "--skip-install"}, args...))
 		}
-		for name, spec := range pkgs {
-			if spec != "" {
+		for name, coords := range pkgs {
+			if coords.Spec != "" {
 				nameArg := string(name)
-				versionArg := "--version=" + string(spec)
+				versionArg := "--version=" + string(coords.Spec)
 				util.RunCmd([]string{"bundle", "add", nameArg, versionArg})
 			}
 		}

--- a/internal/backends/rust/rust.go
+++ b/internal/backends/rust/rust.go
@@ -237,7 +237,7 @@ var RustBackend = api.LanguageBackend{
 	},
 	Search: search,
 	Info:   info,
-	Add: func(ctx context.Context, pkgs map[api.PkgName]api.PkgSpec, projectName string) {
+	Add: func(ctx context.Context, pkgs map[api.PkgName]api.PkgCoordinates, projectName string) {
 		//nolint:ineffassign,wastedassign,staticcheck
 		span, ctx := tracer.StartSpanFromContext(ctx, "cargo add")
 		defer span.Finish()
@@ -245,10 +245,10 @@ var RustBackend = api.LanguageBackend{
 			util.RunCmd([]string{"cargo", "init", "."})
 		}
 		cmd := []string{"cargo", "add"}
-		for name, spec := range pkgs {
+		for name, coords := range pkgs {
 			arg := string(name)
-			if spec != "" {
-				arg += "@" + string(spec)
+			if coords.Spec != "" {
+				arg += "@" + string(coords.Spec)
 			}
 			cmd = append(cmd, arg)
 		}

--- a/internal/cli/cmds.go
+++ b/internal/cli/cmds.go
@@ -350,12 +350,7 @@ func runAdd(
 	}
 
 	if len(normPkgs) >= 1 {
-		pkgs := map[api.PkgName]api.PkgSpec{}
-		for _, nameAndSpec := range normPkgs {
-			pkgs[api.PkgName(nameAndSpec.Name)] = nameAndSpec.Spec
-		}
-
-		b.Add(ctx, pkgs, name)
+		b.Add(ctx, normPkgs, name)
 	}
 
 	if len(normPkgs) == 0 || b.QuirksDoesAddRemoveNotAlsoLock() {

--- a/internal/cli/cmds.go
+++ b/internal/cli/cmds.go
@@ -338,7 +338,8 @@ func runAdd(
 	if util.Exists(b.Specfile) {
 		s := silenceSubroutines()
 		for name, spec := range b.ListSpecfile(true) {
-			if spec == normPkgs[b.NormalizePackageName(name)].Spec {
+			coords := normPkgs[b.NormalizePackageName(name)]
+			if spec == coords.Spec && coords.Extra == nil {
 				delete(normPkgs, b.NormalizePackageName(name))
 			}
 		}


### PR DESCRIPTION
Why
===

![image](https://github.com/user-attachments/assets/d143bb22-fb05-43cd-bcfb-c15c2b3b5efa)

What changed
============

- Break `((?:extras)?(?:version)?)` into `(extras)?(version?)`
- Thread `PkgCoordinates` through to `Add` instead of the limited resolution `PkgSpec`
- Explicitly integrate `Extra` into `pep440Join` instead of just hoping everything works

Test plan
=========

- CI