### PR TITLE
[uv] use torch cpu integration instead of env var

### DIFF
--- a/internal/util/toml-editor.go
+++ b/internal/util/toml-editor.go
@@ -1,0 +1,77 @@
+package util
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os/exec"
+)
+
+// TomlEditorOp is the format of the JSON sent to toml-editor
+type TomlEditorOp struct {
+	Op              string `json:"op"`
+	Path            string `json:"path,omitempty"`
+	TableHeaderPath string `json:"table_header_path,omitempty"`
+	Value           string `json:"value,omitempty"`
+}
+
+// TomlEditorResponse is the format of the JSON sent from toml-editor
+type TomlEditorResponse struct {
+	Status  string        `json:"status"`
+	Message string        `json:"message"`
+	Results []interface{} `json:"results"`
+}
+
+func TomlEditorIsAvailable() bool {
+	_, err := exec.LookPath("toml-editor")
+	return err == nil
+}
+
+func ExecTomlEditor(tomlPath string, ops []TomlEditorOp) (*TomlEditorResponse, error) {
+	cmd := exec.Command("toml-editor", "--path", tomlPath)
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, fmt.Errorf("toml-editor error: %s", err)
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("toml-editor error: %s", err)
+	}
+	err = cmd.Start()
+	if err != nil {
+		return nil, fmt.Errorf("toml-editor error: %s", err)
+	}
+
+	encoder := json.NewEncoder(stdin)
+	err = encoder.Encode(ops)
+	if err != nil {
+		return nil, fmt.Errorf("toml-editor error: %s", err)
+	}
+	decoder := json.NewDecoder(stdout)
+	var tomlEditorResponse TomlEditorResponse
+	err = decoder.Decode(&tomlEditorResponse)
+	if err != nil {
+		if !errors.Is(err, io.EOF) {
+			return nil, fmt.Errorf("unexpected toml-editor output: %s", err)
+		}
+	}
+	if tomlEditorResponse.Status != "success" {
+		input, _ := json.Marshal(ops)
+		return nil, fmt.Errorf("toml-editor error with input %s: %s", input, tomlEditorResponse.Message)
+	}
+
+	stdout.Close()
+	err = stdin.Close()
+	if err != nil {
+		return nil, fmt.Errorf("toml-editor error: %s", err)
+	}
+
+	err = cmd.Wait()
+	if err != nil {
+		input, _ := json.Marshal(ops)
+		return nil, fmt.Errorf("toml-editor error with input %s: %s", input, err)
+	}
+
+	return &tomlEditorResponse, nil
+}


### PR DESCRIPTION
Why
===

- #320 doesn't seem to work on replit, I think we're running into https://github.com/astral-sh/uv/issues/9647
- Using the [pytorch integration
](https://docs.astral.sh/uv/guides/integration/pytorch/#using-a-pytorch-index) with the latest nightly uv seems to fix the issue

What changed
============

- Check to see if torch is in the added packages or already in the spec file and if so, idempotently add the torch cpu override to `pyproject.toml` using `toml-editor`

Test plan
=========

- Running locally as well as on replit should work now:

<img width="1481" alt="image" src="https://github.com/user-attachments/assets/7575fa67-89b5-4d74-b696-68e3bf5ccb21" />
