### PR TITLE
prevent guessing when unavailable

### DIFF
--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -165,7 +165,7 @@ func GuessWithCache(ctx context.Context, b api.LanguageBackend, forceGuess bool)
 	if forceGuess || new != old {
 		var pkgs map[string][]api.PkgName
 		success := true
-		if new != "" {
+		if new != "" && b.Guess != nil {
 			pkgs, success = b.Guess(ctx)
 		} else {
 			// If new is the empty string, that means


### PR DESCRIPTION
Why
===
when running `upm guess` we don't want packages that do not have a implemented `Guess` functionality to error. 
 
What changed
============
add a safety check to skip `b.Guess()` if it's not implemented. We'll return an empty `pkgs` instead. 

Test plan
=========
building and running locally for a pkg that doesn't support `Guess` doesn't error. 

With the nil check:
<img width="202" alt="image" src="https://github.com/user-attachments/assets/e4be97bc-7ea6-4229-bba5-a80e13e81438" />

Without (previous behavior)
<img width="565" alt="image" src="https://github.com/user-attachments/assets/76f3ec9e-1683-4763-97e3-18b2b380b393" />

