### PR TITLE
[chore] bump flake

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,2 @@
+use flake
+dotenv_if_exists

--- a/flake.lock
+++ b/flake.lock
@@ -84,11 +84,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1724999960,
-        "narHash": "sha256-LB3jqSGW5u1ZcUcX6vO/qBOq5oXHlmOCxsTXGMEitp4=",
+        "lastModified": 1741310760,
+        "narHash": "sha256-aizILFrPgq/W53Jw8i0a1h1GZAAKtlYOrG/A5r46gVM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b96f849e725333eb2b1c7f1cb84ff102062468ba",
+        "rev": "de0fe301211c267807afd11b12613f5511ff7433",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Why
===

Separating the flake out from #336.

At first blush it seems as though newer versions of go structure the cache in a way that's incompatible with [`build-go-cache#get-external-imports`](https://github.com/numtide/build-go-cache?tab=readme-ov-file#usage).

What changed
============

- Upgrading flake.
- Also adding direnv

Test plan
=========

_Describe what you did to test this change to a level of detail that allows your reviewer to test it_
