### PR TITLE
Make whichLanguage -l still respect availability

### DIFF
--- a/internal/cli/cmds.go
+++ b/internal/cli/cmds.go
@@ -45,7 +45,9 @@ func (s *subroutineSilencer) restore() {
 func runWhichLanguage(language string, all bool) {
 	if !all {
 		b := backends.GetBackend(context.Background(), language)
-		fmt.Println(b.Name)
+		if b.IsAvailable() {
+			fmt.Println(b.Name)
+		}
 		return
 	}
 	for _, bi := range backends.GetBackendNames() {


### PR DESCRIPTION
Why
===

In a pnpm project, when asking for `-l python`, I get `python3-uv` even though uv is not configured for that project:

```
$ upm which-language -l python
python3-uv
$ upm which-language -a  # Note, does not include python3-uv
nodejs-pnpm
```

We were not checking whether the backend is available before printing

What changed
============

Make `which-languages -l ...` respect the semantics of `which-languages -a`

Test plan
=========

_Describe what you did to test this change to a level of detail that allows your reviewer to test it_
