### PR TITLE
[python] don't attempt systemdep install if no deps

### DIFF
--- a/internal/backends/python/python.go
+++ b/internal/backends/python/python.go
@@ -355,6 +355,11 @@ func commonInstallDotReplitNixDeps(ctx context.Context, pkgs []api.PkgName, spec
 		keys = append(keys, key)
 	}
 	slices.Sort(keys)
+
+	if len(keys) == 0 {
+		return
+	}
+
 	value, err := json.Marshal(keys)
 	if err != nil {
 		util.DieSubprocess("failed to marshal JSON: %s", err)


### PR DESCRIPTION
Why
===

_Describe what prompted you to make this change, link relevant resources: tasks, reports, discussions, etc

If no system dependencies are found, don't to toml-editor nop.

What changed
============

_Describe what changed to a level of detail that someone with no context with your PR could be able to review it_
Check if no system dependencies need to be installed for python packages.

Test plan
=========

_Describe what you did to test this change to a level of detail that allows your reviewer to test it_
