### PR TITLE
Support both bun.lock and bun.lockb lockfile formats

### DIFF
--- a/internal/backends/nodejs/nodejs.go
+++ b/internal/backends/nodejs/nodejs.go
@@ -705,7 +705,8 @@ func makeBunBackend() api.LanguageBackend {
 		Lockfile:    lockfile,
 		IsAvailable: bunIsAvailable,
 		IsActive: func() bool {
-			return commonIsActive(lockfile)
+			// Check for both possible lockfile formats to handle version transitions
+			return commonIsActive("bun.lock") || commonIsActive("bun.lockb")
 		},
 		FilenamePatterns: nodejsPatterns,
 		Quirks: api.QuirksAddRemoveAlsoLocks |


### PR DESCRIPTION
Why
===

Currently we're not treating `bun.lock` as a special file since the file was changed from `bun.lockb` in version 1.2. Additionally, we do not trigger bun on the build when deploying in the presence of a `bun.lock` file.

I made the updates in Replit Web here: https://github.com/replit/repl-it-web/pull/57665

This PR is to address that `bun.lock` is not recognized.

If `bun.lockb` is present and bun > 1.2 is present, UPM successfully upgrades `bun.lockb` to `bun.lock` and uses bun.

However, the builder does not use bun on deployment with version greater than 1.2 and `bun.lock` solely in the file system.

What changed
============

_Describe what changed to a level of detail that someone with no context with your PR could be able to review it_

Test plan
=========

_Describe what you did to test this change to a level of detail that allows your reviewer to test it_
