### PR TITLE
ci: remove pull_request_target trigger from release-drafter

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -9,9 +9,6 @@ on:
   pull_request:
     # Only following types are handled by the action, but one can default to all as well
     types: [opened, reopened, synchronize]
-  # pull_request_target event is required for autolabeler to support PRs from forks
-  pull_request_target:
-    types: [opened, reopened, synchronize]
 
 permissions:
   contents: read


### PR DESCRIPTION
Why
===

The recent [TanStack NPM supply-chain compromise postmortem](https://tanstack.com/blog/npm-supply-chain-compromise-postmortem) describes how an attacker exploited a `pull_request_target` workflow to exfiltrate secrets via a PR from a fork. Per security policy, we're removing `pull_request_target` triggers from all Replit-owned public repos as a precaution — even where the current use looks safe — to eliminate exposure to that attack pattern.

Slack thread: https://replit.slack.com/archives/C03FS477T17/p1778588219046429

What changed
============

Deleted the `pull_request_target` trigger block from `.github/workflows/release-drafter.yml`. No other changes.

Trade-off: the release-drafter autolabeler will no longer run on PRs opened from forks. Release notes are still drafted on push to `main`, and the autolabeler still runs on PRs from branches inside this repo via the existing `pull_request` trigger.

Test plan
=========

- Diff is one workflow file, three lines removed (the `pull_request_target:` key, its `types:` list, and the preceding explanatory comment).
- `release-drafter.yml` remains syntactically valid YAML with the `push: branches: [main]` and `pull_request:` triggers intact, so the workflow continues to run on merges to `main` and on internal PRs.

Revertibility
=============

Safe to revert — single workflow file, no schema or data changes. Re-adding the trigger block restores prior behavior.

~ written by Zerg :space_invader: ([mutated-hydralisk-73a8](https://zerg.zergrush.dev/chat?id=mutated-hydralisk-73a8))